### PR TITLE
Add read options when reading from todo storage file

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ A collection of utilities to generate and store lint item metadata.
 Those utilities are:
 
 <!--DOCS_START-->
-
 ## Functions
 
 <dl>
@@ -48,14 +47,14 @@ hash to identify each.</p>
 <p>Given a list of todo lint violations, this function will also delete existing files that no longer
 have a todo lint violation.</p>
 </dd>
-<dt><a href="#readTodos">readTodos(baseDir, shouldLock)</a> ⇒</dt>
-<dd><p>Reads all todo files in the .lint-todo directory.</p>
+<dt><a href="#readTodos">readTodos(baseDir, options, shouldLock)</a> ⇒</dt>
+<dd><p>Reads all todo files in the .lint-todo file.</p>
 </dd>
-<dt><a href="#readTodosForFilePath">readTodosForFilePath(todoStorageDir, filePath, shouldLock)</a> ⇒</dt>
-<dd><p>Reads todo files in the .lint-todo directory for a specific filePath.</p>
+<dt><a href="#readTodosForFilePath">readTodosForFilePath(baseDir, options, shouldLock)</a> ⇒</dt>
+<dd><p>Reads todo files in the .lint-todo file for a specific filePath.</p>
 </dd>
-<dt><a href="#readTodoData">readTodoData(baseDir)</a> ⇒</dt>
-<dd><p>Reads todo files in the .lint-todo directory and returns Todo data in an array.</p>
+<dt><a href="#readTodoData">readTodoData(baseDir, options)</a> ⇒</dt>
+<dd><p>Reads todo files in the .lint-todo file and returns Todo data in an array.</p>
 </dd>
 <dt><a href="#getTodoBatches">getTodoBatches(maybeTodos, existing, options)</a> ⇒</dt>
 <dd><p>Gets 4 maps containing todo items to add, remove, those that are expired, or those that are stable (not to be modified).</p>
@@ -100,260 +99,243 @@ Config values can be present in</p>
 <a name="buildTodoDatum"></a>
 
 ## buildTodoDatum(lintResult, lintMessage, todoConfig) ⇒
-
 Adapts a [LintResult](https://github.com/lint-todo/utils/blob/master/src/types/lint.ts#L31) to a [TodoData](https://github.com/lint-todo/utils/blob/master/src/types/todo.ts#L61). FilePaths are absolute
 when received from a lint result, so they're converted to relative paths for stability in
 serializing the contents to disc.
 
-**Kind**: global function
-**Returns**: - A [TodoData](https://github.com/lint-todo/utils/blob/master/src/types/todo.ts#L61) object.
+**Kind**: global function  
+**Returns**: - A [TodoData](https://github.com/lint-todo/utils/blob/master/src/types/todo.ts#L61) object.  
 
-| Param       | Description                                                         |
-| ----------- | ------------------------------------------------------------------- |
-| lintResult  | The lint result object.                                             |
+| Param | Description |
+| --- | --- |
+| lintResult | The lint result object. |
 | lintMessage | A lint message object representing a specific violation for a file. |
-| todoConfig  | An object containing the warn or error days, in integers.           |
+| todoConfig | An object containing the warn or error days, in integers. |
 
 <a name="todoStorageFileExists"></a>
 
 ## todoStorageFileExists(baseDir) ⇒
-
 Determines if the .lint-todo storage file exists.
 
-**Kind**: global function
-**Returns**: - true if the todo storage file exists, otherwise false.
+**Kind**: global function  
+**Returns**: - true if the todo storage file exists, otherwise false.  
 
-| Param   | Description                                                   |
-| ------- | ------------------------------------------------------------- |
+| Param | Description |
+| --- | --- |
 | baseDir | The base directory that contains the .lint-todo storage file. |
 
 <a name="ensureTodoStorageFile"></a>
 
 ## ensureTodoStorageFile(baseDir) ⇒
-
 Creates, or ensures the creation of, the .lint-todo file.
 
-**Kind**: global function
-**Returns**: - The todo storage file path.
+**Kind**: global function  
+**Returns**: - The todo storage file path.  
 
-| Param   | Description                                                   |
-| ------- | ------------------------------------------------------------- |
+| Param | Description |
+| --- | --- |
 | baseDir | The base directory that contains the .lint-todo storage file. |
 
 <a name="getTodoStorageFilePath"></a>
 
 ## getTodoStorageFilePath(baseDir) ⇒
+**Kind**: global function  
+**Returns**: - The todo storage file path.  
 
-**Kind**: global function
-**Returns**: - The todo storage file path.
-
-| Param   | Description                                                   |
-| ------- | ------------------------------------------------------------- |
+| Param | Description |
+| --- | --- |
 | baseDir | The base directory that contains the .lint-todo storage file. |
 
 <a name="hasConflicts"></a>
 
 ## hasConflicts(todoContents) ⇒
-
 Determines if the .lint-todo storage file has conflicts.
 
-**Kind**: global function
-**Returns**: true if the file has conflicts, otherwise false.
+**Kind**: global function  
+**Returns**: true if the file has conflicts, otherwise false.  
 
-| Param        | Description                                   |
-| ------------ | --------------------------------------------- |
+| Param | Description |
+| --- | --- |
 | todoContents | The unparsed contents of the .lint-todo file. |
 
 <a name="resolveConflicts"></a>
 
 ## resolveConflicts(operations) ⇒
-
 Resolves git conflicts in todo operations by removing any lines that match conflict markers.
 
-**Kind**: global function
-**Returns**: An array of string operations excluding any operations that were identified as git conflict lines.
+**Kind**: global function  
+**Returns**: An array of string operations excluding any operations that were identified as git conflict lines.  
 
-| Param      | Description                                                    |
-| ---------- | -------------------------------------------------------------- |
+| Param | Description |
+| --- | --- |
 | operations | An array of string operations that are used to recreate todos. |
 
 <a name="readTodoStorageFile"></a>
 
 ## readTodoStorageFile(todoStorageFilePath) ⇒
-
 Reads the .lint-todo storage file.
 
-**Kind**: global function
-**Returns**: A array of todo operations.
+**Kind**: global function  
+**Returns**: A array of todo operations.  
 
-| Param               | Description                       |
-| ------------------- | --------------------------------- |
+| Param | Description |
+| --- | --- |
 | todoStorageFilePath | The .lint-todo storage file path. |
 
 <a name="writeTodoStorageFile"></a>
 
 ## writeTodoStorageFile(todoStorageFilePath, operations)
-
 Writes the operations to the .lint-todo storage file to the path provided by todoStorageFilePath.
 
-**Kind**: global function
+**Kind**: global function  
 
-| Param               | Description                                                    |
-| ------------------- | -------------------------------------------------------------- |
-| todoStorageFilePath | The .lint-todo storage file path.                              |
-| operations          | An array of string operations that are used to recreate todos. |
+| Param | Description |
+| --- | --- |
+| todoStorageFilePath | The .lint-todo storage file path. |
+| operations | An array of string operations that are used to recreate todos. |
 
 <a name="writeTodos"></a>
 
 ## writeTodos(baseDir, maybeTodos, options) ⇒
-
 Writes files for todo lint violations. One file is generated for each violation, using a generated
 hash to identify each.
 
 Given a list of todo lint violations, this function will also delete existing files that no longer
 have a todo lint violation.
 
-**Kind**: global function
-**Returns**: - The counts of added and removed todos.
+**Kind**: global function  
+**Returns**: - The counts of added and removed todos.  
 
-| Param      | Description                                                        |
-| ---------- | ------------------------------------------------------------------ |
-| baseDir    | The base directory that contains the .lint-todo storage directory. |
-| maybeTodos | The linting data, converted to TodoData format.                    |
-| options    | An object containing write options.                                |
+| Param | Description |
+| --- | --- |
+| baseDir | The base directory that contains the .lint-todo storage file. |
+| maybeTodos | The linting data, converted to TodoData format. |
+| options | An object containing write options. |
 
 <a name="readTodos"></a>
 
-## readTodos(baseDir, shouldLock) ⇒
+## readTodos(baseDir, options, shouldLock) ⇒
+Reads all todo files in the .lint-todo file.
 
-Reads all todo files in the .lint-todo directory.
+**Kind**: global function  
+**Returns**: - A [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) of [FilePath](https://github.com/lint-todo/utils/blob/master/src/types/todo.ts#L25)/[TodoMatcher](https://github.com/lint-todo/utils/blob/master/src/todo-matcher.ts#L4).  
 
-**Kind**: global function
-**Returns**: - A [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) of [FilePath](https://github.com/lint-todo/utils/blob/master/src/types/todo.ts#L25)/[TodoMatcher](https://github.com/lint-todo/utils/blob/master/src/todo-matcher.ts#L4).
-
-| Param      | Default           | Description                                                                           |
-| ---------- | ----------------- | ------------------------------------------------------------------------------------- |
-| baseDir    |                   | The base directory that contains the .lint-todo storage directory.                    |
+| Param | Default | Description |
+| --- | --- | --- |
+| baseDir |  | The base directory that contains the .lint-todo storage file. |
+| options |  | An object containing read options. |
 | shouldLock | <code>true</code> | True if the .lint-todo storage file should be locked, otherwise false. Default: true. |
 
 <a name="readTodosForFilePath"></a>
 
-## readTodosForFilePath(todoStorageDir, filePath, shouldLock) ⇒
+## readTodosForFilePath(baseDir, options, shouldLock) ⇒
+Reads todo files in the .lint-todo file for a specific filePath.
 
-Reads todo files in the .lint-todo directory for a specific filePath.
+**Kind**: global function  
+**Returns**: - A [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) of [FilePath](https://github.com/lint-todo/utils/blob/master/src/types/todo.ts#L25)/[TodoMatcher](https://github.com/lint-todo/utils/blob/master/src/todo-matcher.ts#L4).  
 
-**Kind**: global function
-**Returns**: - A [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) of [FilePath](https://github.com/lint-todo/utils/blob/master/src/types/todo.ts#L25)/[TodoMatcher](https://github.com/lint-todo/utils/blob/master/src/todo-matcher.ts#L4).
-
-| Param          | Description                                                                           |
-| -------------- | ------------------------------------------------------------------------------------- |
-| todoStorageDir | The .lint-todo storage directory.                                                     |
-| filePath       | The relative file path of the file to return todo items for.                          |
-| shouldLock     | True if the .lint-todo storage file should be locked, otherwise false. Default: true. |
+| Param | Default | Description |
+| --- | --- | --- |
+| baseDir |  | The base directory that contains the .lint-todo storage file. |
+| options |  | An object containing read options. |
+| shouldLock | <code>true</code> | True if the .lint-todo storage file should be locked, otherwise false. Default: true. |
 
 <a name="readTodoData"></a>
 
-## readTodoData(baseDir) ⇒
+## readTodoData(baseDir, options) ⇒
+Reads todo files in the .lint-todo file and returns Todo data in an array.
 
-Reads todo files in the .lint-todo directory and returns Todo data in an array.
+**Kind**: global function  
+**Returns**: An array of [TodoData](https://github.com/lint-todo/utils/blob/master/src/types/todo.ts#L61)  
 
-**Kind**: global function
-**Returns**: An array of [TodoData](https://github.com/lint-todo/utils/blob/master/src/types/todo.ts#L61)
-
-| Param   | Description                                                        |
-| ------- | ------------------------------------------------------------------ |
-| baseDir | The base directory that contains the .lint-todo storage directory. |
+| Param | Description |
+| --- | --- |
+| baseDir | The base directory that contains the .lint-todo storage file. |
+| options | An object containing read options. |
 
 <a name="getTodoBatches"></a>
 
 ## getTodoBatches(maybeTodos, existing, options) ⇒
-
 Gets 4 maps containing todo items to add, remove, those that are expired, or those that are stable (not to be modified).
 
-**Kind**: global function
-**Returns**: - An object of [TodoBatches](https://github.com/lint-todo/utils/blob/master/src/types/todo.ts#L36).
+**Kind**: global function  
+**Returns**: - An object of [TodoBatches](https://github.com/lint-todo/utils/blob/master/src/types/todo.ts#L36).  
 
-| Param      | Description                         |
-| ---------- | ----------------------------------- |
-| maybeTodos | The linting data for violations.    |
-| existing   | Existing todo lint data.            |
-| options    | An object containing write options. |
+| Param | Description |
+| --- | --- |
+| maybeTodos | The linting data for violations. |
+| existing | Existing todo lint data. |
+| options | An object containing write options. |
 
 <a name="applyTodoChanges"></a>
 
 ## applyTodoChanges(baseDir, add, remove, shouldLock)
-
 Applies todo changes, either adding or removing, based on batches from `getTodoBatches`.
 
-**Kind**: global function
+**Kind**: global function  
 
-| Param      | Default           | Description                                                                           |
-| ---------- | ----------------- | ------------------------------------------------------------------------------------- |
-| baseDir    |                   | The base directory that contains the .lint-todo storage directory.                    |
-| add        |                   | Batch of todos to add.                                                                |
-| remove     |                   | Batch of todos to remove.                                                             |
+| Param | Default | Description |
+| --- | --- | --- |
+| baseDir |  | The base directory that contains the .lint-todo storage file. |
+| add |  | Batch of todos to add. |
+| remove |  | Batch of todos to remove. |
 | shouldLock | <code>true</code> | True if the .lint-todo storage file should be locked, otherwise false. Default: true. |
 
 <a name="ADD_OPERATIONS_ONLY"></a>
 
-## ADD_OPERATIONS_ONLY(operation) ⇒
-
+## ADD\_OPERATIONS\_ONLY(operation) ⇒
 Compact strategy to leave only add operations in the todo storage file.
 
-**Kind**: global function
-**Returns**: True if the line matches an add operation, otherwise false.
+**Kind**: global function  
+**Returns**: True if the line matches an add operation, otherwise false.  
 
-| Param     | Description                                                |
-| --------- | ---------------------------------------------------------- |
+| Param | Description |
+| --- | --- |
 | operation | The single line operation read from the todo storage file. |
 
 <a name="EXCLUDE_EXPIRED"></a>
 
-## EXCLUDE_EXPIRED(operation) ⇒
-
+## EXCLUDE\_EXPIRED(operation) ⇒
 Compact strategy to remove all expired operations from the todo storage file.
 
-**Kind**: global function
-**Returns**: True if the operation is not expired, otherwise false.
+**Kind**: global function  
+**Returns**: True if the operation is not expired, otherwise false.  
 
-| Param     | Description                                                |
-| --------- | ---------------------------------------------------------- |
+| Param | Description |
+| --- | --- |
 | operation | The single line operation read from the todo storage file. |
 
 <a name="compactTodoStorageFile"></a>
 
 ## compactTodoStorageFile(baseDir, compactStrategy) ⇒
-
 Compacts the .lint-todo storage file based on the compact strategy.
 
-**Kind**: global function
-**Returns**: The count of compacted todos.
+**Kind**: global function  
+**Returns**: The count of compacted todos.  
 
-| Param           | Description                                                                        |
-| --------------- | ---------------------------------------------------------------------------------- |
-| baseDir         | The base directory that contains the .lint-todo storage directory.                 |
+| Param | Description |
+| --- | --- |
+| baseDir | The base directory that contains the .lint-todo storage file. |
 | compactStrategy | The strategy to use when compacting the storage file. Default: ADD_OPERATIONS_ONLY |
 
 <a name="getTodoConfig"></a>
 
 ## getTodoConfig(baseDir, engine, customDaysToDecay) ⇒
-
 Gets the todo configuration.
 Config values can be present in
 
 The package.json
 
-**Kind**: global function
-**Returns**: - The todo config object.
+**Kind**: global function  
+**Returns**: - The todo config object.  
 
-| Param             | Description                                                  |
-| ----------------- | ------------------------------------------------------------ |
-| baseDir           | The base directory that contains the project's package.json. |
-| engine            | The engine for this configuration, eg. eslint                |
-| customDaysToDecay | The optional custom days to decay configuration.             |
+| Param | Description |
+| --- | --- |
+| baseDir | The base directory that contains the project's package.json. |
+| engine | The engine for this configuration, eg. eslint |
+| customDaysToDecay | The optional custom days to decay configuration. |
 
-**Example**
-
+**Example**  
 ```json
 {
   "lintTodo": {
@@ -371,104 +353,100 @@ The package.json
 ```
 
 A .lint-todorc.js file
-**Example**
-
+**Example**  
 ```js
 module.exports = {
-  'some-engine': {
-    daysToDecay: {
-      warn: 5,
-      error: 10,
+  "some-engine": {
+    "daysToDecay": {
+      "warn": 5,
+      "error": 10
     },
-    daysToDecayByRule: {
-      'no-bare-strings': { warn: 10, error: 20 },
-    },
-  },
-};
+    "daysToDecayByRule": {
+      "no-bare-strings": { "warn": 10, "error": 20 }
+    }
+  }
+}
 ```
 
-Environment variables (`TODO_DAYS_TO_WARN` or `TODO_DAYS_TO_ERROR`) - Env vars override package.json config
+Environment variables (`TODO_DAYS_TO_WARN` or `TODO_DAYS_TO_ERROR`)
+	- Env vars override package.json config
 
-Passed in directly, such as from command line options. - Passed in options override both env vars and package.json config
+Passed in directly, such as from command line options.
+	- Passed in options override both env vars and package.json config
 <a name="validateConfig"></a>
 
 ## validateConfig(baseDir) ⇒
-
 Validates whether we have a unique config in a single location.
 
-**Kind**: global function
-**Returns**: A ConfigValidationResult that indicates whether a config is unique
+**Kind**: global function  
+**Returns**: A ConfigValidationResult that indicates whether a config is unique  
 
-| Param   | Description                                                  |
-| ------- | ------------------------------------------------------------ |
+| Param | Description |
+| --- | --- |
 | baseDir | The base directory that contains the project's package.json. |
 
 <a name="getSeverity"></a>
 
 ## getSeverity(todo, today) ⇒
-
 Returns the correct severity level based on the todo data's decay dates.
 
-**Kind**: global function
-**Returns**: Severity - the lint severity based on the evaluation of the decay dates.
+**Kind**: global function  
+**Returns**: Severity - the lint severity based on the evaluation of the decay dates.  
 
-| Param | Description                                              |
-| ----- | -------------------------------------------------------- |
-| todo  | The todo data.                                           |
+| Param | Description |
+| --- | --- |
+| todo | The todo data. |
 | today | A number representing a date (UNIX Epoch - milliseconds) |
 
 <a name="isExpired"></a>
 
 ## isExpired(date, today) ⇒
-
 Evaluates whether a date is expired (earlier than today)
 
-**Kind**: global function
-**Returns**: true if the date is earlier than today, otherwise false
+**Kind**: global function  
+**Returns**: true if the date is earlier than today, otherwise false  
 
-| Param | Description                                              |
-| ----- | -------------------------------------------------------- |
-| date  | The date to evaluate                                     |
+| Param | Description |
+| --- | --- |
+| date | The date to evaluate |
 | today | A number representing a date (UNIX Epoch - milliseconds) |
 
 <a name="getDatePart"></a>
 
 ## getDatePart(date) ⇒
-
 Converts a date to include year, month, and day values only (time is zeroed out).
 
-**Kind**: global function
-**Returns**: Date - A date with the time zeroed out eg. '2021-01-01T08:00:00.000Z'
+**Kind**: global function  
+**Returns**: Date - A date with the time zeroed out eg. '2021-01-01T08:00:00.000Z'  
 
-| Param | Description         |
-| ----- | ------------------- |
-| date  | The date to convert |
+| Param | Description |
+| --- | --- |
+| date | The date to convert |
 
 <a name="differenceInDays"></a>
 
 ## differenceInDays(startDate, endDate) ⇒
-
 Returns the difference in days between two dates.
 
-**Kind**: global function
-**Returns**: a number representing the days between the dates
+**Kind**: global function  
+**Returns**: a number representing the days between the dates  
 
-| Param     | Description    |
-| --------- | -------------- |
+| Param | Description |
+| --- | --- |
 | startDate | The start date |
-| endDate   | The end date   |
+| endDate | The end date |
 
 <a name="format"></a>
 
 ## format(date) ⇒
-
 Formats the date in short form, eg. 2021-01-01
 
-**Kind**: global function
-**Returns**: A string representing the formatted date
+**Kind**: global function  
+**Returns**: A string representing the formatted date  
 
-| Param | Description        |
-| ----- | ------------------ |
-| date  | The date to format |
+| Param | Description |
+| --- | --- |
+| date | The date to format |
+
 
 <!--DOCS_END-->

--- a/__tests__/__fixtures__/ember-template-lint-with-errors.json
+++ b/__tests__/__fixtures__/ember-template-lint-with-errors.json
@@ -1,0 +1,74 @@
+[
+  {
+    "filePath": "app/components/foo.hbs",
+    "messages": [
+      {
+        "rule": "no-html-comments",
+        "severity": 2,
+        "filePath": "app/components/foo.hbs",
+        "line": 5,
+        "column": 0,
+        "endLine": 5,
+        "endColumn": 27,
+        "source": "<!-- And I'm a comment! -->",
+        "message": "HTML comment detected",
+        "fix": {
+          "text": "{{! And I'm a comment! }}"
+        }
+      },
+      {
+        "rule": "no-bare-strings",
+        "severity": 2,
+        "filePath": "app/components/foo.hbs",
+        "line": 3,
+        "column": 5,
+        "endLine": 3,
+        "endColumn": 30,
+        "source": "I'm a bad bad bare string",
+        "message": "Non-translated string used"
+      }
+    ],
+    "errorCount": 2,
+    "warningCount": 0,
+    "todoCount": 0,
+    "fixableErrorCount": 0,
+    "fixableWarningCount": 0,
+    "fixableTodoCount": 0
+  },
+  {
+    "filePath": "app/templates/application.hbs",
+    "messages": [
+      {
+        "rule": "no-html-comments",
+        "severity": 2,
+        "filePath": "app/templates/application.hbs",
+        "line": 4,
+        "column": 34,
+        "endLine": 4,
+        "endColumn": 54,
+        "source": "<!-- bad comment -->",
+        "message": "HTML comment detected",
+        "fix": {
+          "text": "{{! bad comment }}"
+        }
+      },
+      {
+        "rule": "no-bare-strings",
+        "severity": 2,
+        "filePath": "app/templates/application.hbs",
+        "line": 4,
+        "column": 5,
+        "endLine": 4,
+        "endColumn": 28,
+        "source": "This is a bare string!!",
+        "message": "Non-translated string used"
+      }
+    ],
+    "errorCount": 2,
+    "warningCount": 0,
+    "todoCount": 0,
+    "fixableErrorCount": 0,
+    "fixableWarningCount": 0,
+    "fixableTodoCount": 0
+  }
+]

--- a/__tests__/builders-test.ts
+++ b/__tests__/builders-test.ts
@@ -228,7 +228,7 @@ describe('builders', () => {
         'add|ember-template-lint|no-implicit-this|174|8|174|8|864e3ef2438ac413d96a032cdd141e567fcc04b3|1629331200000|2493248400000|2493334800000|addon/templates/components/foo.hbs',
       ];
 
-      const todos = buildFromTodoOperations(todoOperations);
+      const todos = buildFromTodoOperations(todoOperations, 'ember-template-lint');
 
       expect(todos.size).toEqual(1);
       expect(todos).toMatchInlineSnapshot(`
@@ -265,7 +265,7 @@ describe('builders', () => {
         'add|ember-template-lint|no-implicit-this|174|8|174|8|864e3ef2438ac413d96a032cdd141e567fcc04b3|1629331200000|2493248400000|2493334800000|addon/templates/components/fo|o.hbs',
       ];
 
-      const todos = buildFromTodoOperations(todoOperations);
+      const todos = buildFromTodoOperations(todoOperations, 'ember-template-lint');
 
       expect(todos.size).toEqual(1);
       expect(todos).toMatchInlineSnapshot(`
@@ -303,7 +303,7 @@ describe('builders', () => {
         'add|ember-template-lint|no-implicit-this|174|8|174|8|864e3ef2438ac413d96a032cdd141e567fcc04b3|1629331200000|2493248400000|2493334800000|addon/templates/components/foo.hbs',
       ];
 
-      expect(buildFromTodoOperations(todoOperations)).toMatchInlineSnapshot(`
+      expect(buildFromTodoOperations(todoOperations, 'ember-template-lint')).toMatchInlineSnapshot(`
         Map {
           "addon/templates/components/foo.hbs" => TodoMatcher {
             "unprocessed": Set {
@@ -338,7 +338,9 @@ describe('builders', () => {
         'remove|ember-template-lint|no-implicit-this|174|8|174|8|864e3ef2438ac413d96a032cdd141e567fcc04b3|1629331200000|2493248400000|2493334800000|addon/templates/components/foo.hbs',
       ];
 
-      expect(buildFromTodoOperations(todoOperations)).toMatchInlineSnapshot(`Map {}`);
+      expect(buildFromTodoOperations(todoOperations, 'ember-template-lint')).toMatchInlineSnapshot(
+        `Map {}`
+      );
     });
 
     it('builds empty todos from single add and multiple identical removes', () => {
@@ -348,7 +350,9 @@ describe('builders', () => {
         'remove|ember-template-lint|no-implicit-this|174|8|174|8|864e3ef2438ac413d96a032cdd141e567fcc04b3|1629331200000|2493248400000|2493334800000|addon/templates/components/foo.hbs',
       ];
 
-      expect(buildFromTodoOperations(todoOperations)).toMatchInlineSnapshot(`Map {}`);
+      expect(buildFromTodoOperations(todoOperations, 'ember-template-lint')).toMatchInlineSnapshot(
+        `Map {}`
+      );
     });
   });
 

--- a/__tests__/git-operations-test.ts
+++ b/__tests__/git-operations-test.ts
@@ -153,7 +153,7 @@ describe('git operations', () => {
 
     expect(hasConflicts(storageFileContents)).toEqual(true);
 
-    readTodoData(tmp);
+    readTodoData(tmp, { engine: 'eslint', filePath: '' });
 
     expect(hasConflicts(readTodoStorageFileContents(todoStorageFilePath))).toEqual(false);
     expect(readFileSync(todoStorageFilePath, { encoding: 'utf-8' })).toMatchInlineSnapshot(`
@@ -215,7 +215,7 @@ describe('git operations', () => {
 
     expect(hasConflicts(storageFileContents)).toEqual(true);
 
-    readTodoData(tmp);
+    readTodoData(tmp, { engine: 'eslint', filePath: '' });
 
     expect(hasConflicts(readTodoStorageFileContents(todoStorageFilePath))).toEqual(false);
     expect(readFileSync(todoStorageFilePath, { encoding: 'utf-8' })).toMatchInlineSnapshot(`

--- a/__tests__/io-test.ts
+++ b/__tests__/io-test.ts
@@ -212,7 +212,7 @@ remove|eslint|no-unused-vars|30|19|30|33|da39a3ee5e6b4b0d3255bfef95601890afd8070
   });
 
   describe('writeTodos', () => {
-    it("creates .lint-todo directory if one doesn't exist", async () => {
+    it("creates .lint-todo file if one doesn't exist", async () => {
       const todoFile = getTodoStorageFilePath(tmp);
 
       writeTodos(tmp, new Set(), buildWriteOptions(tmp));

--- a/__tests__/io-test.ts
+++ b/__tests__/io-test.ts
@@ -10,7 +10,15 @@ import {
   writeTodos,
   getTodoConfig,
 } from '../src';
-import { FilePath, LintResult, Operation, OperationOrConflictLine, TodoData } from '../src/types';
+import {
+  FilePath,
+  LintResult,
+  Operation,
+  OperationOrConflictLine,
+  ReadTodoOptions,
+  TodoData,
+  WriteTodoOptions,
+} from '../src/types';
 import { createTmpDir } from './__utils__/tmp-dir';
 import { getFixture } from './__utils__/get-fixture';
 import TodoMatcher from '../src/todo-matcher';
@@ -45,6 +53,30 @@ function stableTodoFragment(todoData: Set<TodoData>) {
       source: todoDatum.source,
     };
   });
+}
+
+function buildWriteOptions(tmp: string, options?: Partial<WriteTodoOptions>) {
+  return Object.assign(
+    {},
+    {
+      engine: 'eslint',
+      filePath: '',
+      todoConfig: getTodoConfig(tmp, 'eslint'),
+      shouldRemove: () => true,
+    },
+    options
+  );
+}
+
+function buildReadOptions(options?: Partial<ReadTodoOptions>) {
+  return Object.assign(
+    {},
+    {
+      engine: 'eslint',
+      filePath: '',
+    },
+    options
+  );
 }
 
 jest.setTimeout(100000);
@@ -183,32 +215,26 @@ remove|eslint|no-unused-vars|30|19|30|33|da39a3ee5e6b4b0d3255bfef95601890afd8070
     it("creates .lint-todo directory if one doesn't exist", async () => {
       const todoFile = getTodoStorageFilePath(tmp);
 
-      writeTodos(tmp, new Set(), {
-        todoConfig: getTodoConfig(tmp, 'eslint'),
-      });
+      writeTodos(tmp, new Set(), buildWriteOptions(tmp));
 
       expect(existsSync(todoFile)).toEqual(true);
     });
 
     it("doesn't write files when no todos provided", async () => {
-      writeTodos(tmp, new Set(), {
-        todoConfig: getTodoConfig(tmp, 'eslint'),
-      });
+      writeTodos(tmp, new Set(), buildWriteOptions(tmp));
 
-      expect(readTodos(tmp).size).toEqual(0);
+      expect(readTodos(tmp, buildReadOptions()).size).toEqual(0);
     });
 
     it('generates todos when todos provided', async () => {
       const { addedCount } = writeTodos(
         tmp,
         buildMaybeTodosFromFixture(tmp, 'eslint-with-errors'),
-        {
-          todoConfig: getTodoConfig(tmp, 'eslint'),
-        }
+        buildWriteOptions(tmp)
       );
 
       expect(addedCount).toEqual(18);
-      expect(readTodoData(tmp).size).toEqual(18);
+      expect(readTodoData(tmp, buildReadOptions()).size).toEqual(18);
     });
 
     it("generates todos only if previous todo doesn't exist", async () => {
@@ -248,35 +274,37 @@ remove|eslint|no-unused-vars|30|19|30|33|da39a3ee5e6b4b0d3255bfef95601890afd8070
         },
       ];
 
-      const { addedCount } = writeTodos(tmp, buildMaybeTodos(tmp, initialTodos), {
-        todoConfig: getTodoConfig(tmp, 'eslint'),
-      });
+      const { addedCount } = writeTodos(
+        tmp,
+        buildMaybeTodos(tmp, initialTodos),
+        buildWriteOptions(tmp)
+      );
 
       expect(addedCount).toEqual(2);
-      expect(readTodoData(tmp).size).toEqual(2);
+      expect(readTodoData(tmp, buildReadOptions()).size).toEqual(2);
 
-      writeTodos(tmp, buildMaybeTodosFromFixture(tmp, 'eslint-with-errors'));
+      writeTodos(
+        tmp,
+        buildMaybeTodosFromFixture(tmp, 'eslint-with-errors'),
+        buildWriteOptions(tmp)
+      );
 
-      const subsequentTodos = readTodoData(tmp);
+      const subsequentTodos = readTodoData(tmp, buildReadOptions());
 
       expect(subsequentTodos.size).toEqual(18);
     });
 
     it('removes old todos if todos no longer contains violations', async () => {
       const fixture = buildMaybeTodosFromFixture(tmp, 'eslint-with-errors');
-      const { addedCount } = writeTodos(tmp, fixture, {
-        todoConfig: getTodoConfig(tmp, 'eslint'),
-      });
-      const initialTodos = readTodoData(tmp);
+      const { addedCount } = writeTodos(tmp, fixture, buildWriteOptions(tmp));
+      const initialTodos = readTodoData(tmp, buildReadOptions());
 
       expect(addedCount).toEqual(18);
       expect(initialTodos.size).toEqual(18);
 
       const [firstHalf] = chunk(fixture, 3);
-      const { removedCount } = writeTodos(tmp, new Set(firstHalf), {
-        todoConfig: getTodoConfig(tmp, 'eslint'),
-      });
-      const subsequentTodos = readTodoData(tmp);
+      const { removedCount } = writeTodos(tmp, new Set(firstHalf), buildWriteOptions(tmp));
+      const subsequentTodos = readTodoData(tmp, buildReadOptions());
 
       expect(removedCount).toEqual(15);
       expect(subsequentTodos.size).toEqual(3);
@@ -285,23 +313,22 @@ remove|eslint|no-unused-vars|30|19|30|33|da39a3ee5e6b4b0d3255bfef95601890afd8070
     it('does not remove old todos if todos no longer contains violations if shouldRemove returns false', async () => {
       const fixture = buildMaybeTodosFromFixture(tmp, 'eslint-with-errors');
 
-      const { addedCount } = writeTodos(tmp, fixture, {
-        todoConfig: getTodoConfig(tmp, 'eslint'),
-      });
+      const { addedCount } = writeTodos(tmp, fixture, buildWriteOptions(tmp));
 
-      const initialFiles = readTodoData(tmp);
+      const initialFiles = readTodoData(tmp, buildReadOptions());
 
       expect(addedCount).toEqual(18);
       expect(initialFiles.size).toEqual(18);
 
       const [firstHalf] = chunk(fixture, 3);
 
-      const { removedCount } = writeTodos(tmp, firstHalf, {
-        todoConfig: getTodoConfig(tmp, 'eslint'),
-        shouldRemove: () => false,
-      });
+      const { removedCount } = writeTodos(
+        tmp,
+        firstHalf,
+        buildWriteOptions(tmp, { shouldRemove: () => false })
+      );
 
-      const subsequentFiles = readTodoData(tmp);
+      const subsequentFiles = readTodoData(tmp, buildReadOptions());
 
       expect(removedCount).toEqual(0);
       expect(subsequentFiles.size).toEqual(18);
@@ -310,13 +337,16 @@ remove|eslint|no-unused-vars|30|19|30|33|da39a3ee5e6b4b0d3255bfef95601890afd8070
 
   describe('writeTodos for single file', () => {
     it('generates todos for a specific filePath', async () => {
-      const { addedCount } = writeTodos(tmp, buildMaybeTodosFromFixture(tmp, 'single-file-todo'), {
-        filePath: 'app/controllers/settings.js',
-        todoConfig: getTodoConfig(tmp, 'eslint'),
-      });
+      const { addedCount } = writeTodos(
+        tmp,
+        buildMaybeTodosFromFixture(tmp, 'single-file-todo'),
+        buildWriteOptions(tmp, {
+          filePath: 'app/controllers/settings.js',
+        })
+      );
 
       expect(addedCount).toEqual(3);
-      expect(stableTodoFragment(readTodoData(tmp))).toMatchInlineSnapshot(`
+      expect(stableTodoFragment(readTodoData(tmp, buildReadOptions()))).toMatchInlineSnapshot(`
         Array [
           Object {
             "filePath": "app/controllers/settings.js",
@@ -365,13 +395,16 @@ remove|eslint|no-unused-vars|30|19|30|33|da39a3ee5e6b4b0d3255bfef95601890afd8070
     });
 
     it('updates todos for a specific filePath', async () => {
-      const { addedCount } = writeTodos(tmp, buildMaybeTodosFromFixture(tmp, 'single-file-todo'), {
-        filePath: 'app/controllers/settings.js',
-        todoConfig: getTodoConfig(tmp, 'eslint'),
-      });
+      const { addedCount } = writeTodos(
+        tmp,
+        buildMaybeTodosFromFixture(tmp, 'single-file-todo'),
+        buildWriteOptions(tmp, {
+          filePath: 'app/controllers/settings.js',
+        })
+      );
 
       expect(addedCount).toEqual(3);
-      expect(stableTodoFragment(readTodoData(tmp))).toMatchInlineSnapshot(`
+      expect(stableTodoFragment(readTodoData(tmp, buildReadOptions()))).toMatchInlineSnapshot(`
         Array [
           Object {
             "filePath": "app/controllers/settings.js",
@@ -418,10 +451,13 @@ remove|eslint|no-unused-vars|30|19|30|33|da39a3ee5e6b4b0d3255bfef95601890afd8070
         ]
       `);
 
-      const counts = writeTodos(tmp, buildMaybeTodosFromFixture(tmp, 'single-file-todo-updated'), {
-        filePath: 'app/controllers/settings.js',
-        todoConfig: getTodoConfig(tmp, 'eslint'),
-      });
+      const counts = writeTodos(
+        tmp,
+        buildMaybeTodosFromFixture(tmp, 'single-file-todo-updated'),
+        buildWriteOptions(tmp, {
+          filePath: 'app/controllers/settings.js',
+        })
+      );
 
       expect(counts).toStrictEqual({
         addedCount: 1,
@@ -429,7 +465,7 @@ remove|eslint|no-unused-vars|30|19|30|33|da39a3ee5e6b4b0d3255bfef95601890afd8070
         removedCount: 1,
         stableCount: 2,
       });
-      expect(stableTodoFragment(readTodoData(tmp))).toMatchInlineSnapshot(`
+      expect(stableTodoFragment(readTodoData(tmp, buildReadOptions()))).toMatchInlineSnapshot(`
         Array [
           Object {
             "filePath": "app/controllers/settings.js",
@@ -478,13 +514,16 @@ remove|eslint|no-unused-vars|30|19|30|33|da39a3ee5e6b4b0d3255bfef95601890afd8070
     });
 
     it('deletes todos for a specific filePath', async () => {
-      const { addedCount } = writeTodos(tmp, buildMaybeTodosFromFixture(tmp, 'single-file-todo'), {
-        filePath: 'app/controllers/settings.js',
-        todoConfig: getTodoConfig(tmp, 'eslint'),
-      });
+      const { addedCount } = writeTodos(
+        tmp,
+        buildMaybeTodosFromFixture(tmp, 'single-file-todo'),
+        buildWriteOptions(tmp, {
+          filePath: 'app/controllers/settings.js',
+        })
+      );
 
       expect(addedCount).toEqual(3);
-      expect(stableTodoFragment(readTodoData(tmp))).toMatchInlineSnapshot(`
+      expect(stableTodoFragment(readTodoData(tmp, buildReadOptions()))).toMatchInlineSnapshot(`
         Array [
           Object {
             "filePath": "app/controllers/settings.js",
@@ -534,54 +573,45 @@ remove|eslint|no-unused-vars|30|19|30|33|da39a3ee5e6b4b0d3255bfef95601890afd8070
       const { addedCount: addedCount2, removedCount } = writeTodos(
         tmp,
         buildMaybeTodosFromFixture(tmp, 'single-file-no-errors'),
-        {
+        buildWriteOptions(tmp, {
           filePath: 'app/controllers/settings.js',
-          todoConfig: getTodoConfig(tmp, 'eslint'),
-        }
+        })
       );
 
       expect(addedCount2).toEqual(0);
       expect(removedCount).toEqual(3);
-      expect(readTodoData(tmp).size).toEqual(0);
+      expect(readTodoData(tmp, buildReadOptions()).size).toEqual(0);
     });
   });
 
   describe('readTodos', () => {
     it('can read empty storage file', () => {
-      writeTodos(tmp, new Set(), {
-        todoConfig: getTodoConfig(tmp, 'eslint'),
-      });
+      writeTodos(tmp, new Set(), buildWriteOptions(tmp));
 
-      expect(readTodos(tmp).size).toEqual(0);
+      expect(readTodos(tmp, buildReadOptions()).size).toEqual(0);
     });
 
     it('can read storage file with adds only', () => {
       const initialTodos = buildMaybeTodosFromFixture(tmp, 'eslint-with-errors');
-      const { addedCount } = writeTodos(tmp, initialTodos, {
-        todoConfig: getTodoConfig(tmp, 'eslint'),
-      });
+      const { addedCount } = writeTodos(tmp, initialTodos, buildWriteOptions(tmp));
 
-      expect(readTodoData(tmp).size).toEqual(addedCount);
+      expect(readTodoData(tmp, buildReadOptions()).size).toEqual(addedCount);
     });
 
     it('can read storage file with adds and removes', () => {
       const initialTodos = buildMaybeTodosFromFixture(tmp, 'eslint-with-errors');
-      const { addedCount } = writeTodos(tmp, initialTodos, {
-        todoConfig: getTodoConfig(tmp, 'eslint'),
-      });
+      const { addedCount } = writeTodos(tmp, initialTodos, buildWriteOptions(tmp));
 
-      expect(readTodoData(tmp).size).toEqual(addedCount);
+      expect(readTodoData(tmp, buildReadOptions()).size).toEqual(addedCount);
 
       const [firstChunk] = chunk(initialTodos, 2);
 
-      const { removedCount } = writeTodos(tmp, firstChunk, {
-        todoConfig: getTodoConfig(tmp, 'eslint'),
-      });
+      const { removedCount } = writeTodos(tmp, firstChunk, buildWriteOptions(tmp));
 
       expect(readTodoStorageFile(getTodoStorageFilePath(tmp))).toHaveLength(
         addedCount + removedCount
       );
-      expect(readTodoData(tmp).size).toEqual(2);
+      expect(readTodoData(tmp, buildReadOptions()).size).toEqual(2);
     });
   });
 
@@ -1038,12 +1068,13 @@ remove|eslint|no-unused-vars|30|19|30|33|da39a3ee5e6b4b0d3255bfef95601890afd8070
     it(`creates only stable and expired batches for exact match`, async () => {
       const { addedCount } = writeTodos(
         tmp,
-        buildMaybeTodosFromFixture(tmp, 'eslint-with-errors-exact-match')
+        buildMaybeTodosFromFixture(tmp, 'eslint-with-errors-exact-match'),
+        buildWriteOptions(tmp)
       );
 
       expect(addedCount).toEqual(5);
 
-      const existing: Map<FilePath, TodoMatcher> = readTodos(tmp);
+      const existing: Map<FilePath, TodoMatcher> = readTodos(tmp, buildReadOptions());
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const expiredTodo: TodoData = existing
         .get('app/components/foo.js')!
@@ -1142,12 +1173,13 @@ remove|eslint|no-unused-vars|30|19|30|33|da39a3ee5e6b4b0d3255bfef95601890afd8070
     it(`creates only stable and expired batches for fuzzy match`, async () => {
       const { addedCount } = writeTodos(
         tmp,
-        buildMaybeTodosFromFixture(tmp, 'eslint-with-errors-exact-match')
+        buildMaybeTodosFromFixture(tmp, 'eslint-with-errors-exact-match'),
+        buildWriteOptions(tmp)
       );
 
       expect(addedCount).toEqual(5);
 
-      const existing: Map<FilePath, TodoMatcher> = readTodos(tmp);
+      const existing: Map<FilePath, TodoMatcher> = readTodos(tmp, buildReadOptions());
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const expiredTodo: TodoData = existing
         .get('app/components/foo.js')!

--- a/__tests__/io-test.ts
+++ b/__tests__/io-test.ts
@@ -613,6 +613,37 @@ remove|eslint|no-unused-vars|30|19|30|33|da39a3ee5e6b4b0d3255bfef95601890afd8070
       );
       expect(readTodoData(tmp, buildReadOptions()).size).toEqual(2);
     });
+
+    it('can read storage file with engine isolation', () => {
+      const eslintTodos = buildMaybeTodosFromFixture(tmp, 'eslint-with-errors');
+      const emberTemplateLintTodos = buildMaybeTodosFromFixture(
+        tmp,
+        'ember-template-lint-with-errors'
+      );
+
+      const { addedCount: eslintAddedCount } = writeTodos(
+        tmp,
+        eslintTodos,
+        buildWriteOptions(tmp, { engine: 'eslint' })
+      );
+      expect(eslintAddedCount).toEqual(18);
+
+      const { addedCount: emberTemplateLintAddedCount } = writeTodos(
+        tmp,
+        emberTemplateLintTodos,
+        buildWriteOptions(tmp, { engine: 'ember-template-lint' })
+      );
+      expect(emberTemplateLintAddedCount).toEqual(4);
+
+      expect(
+        readTodoData(
+          tmp,
+          buildReadOptions({
+            engine: 'ember-template-lint',
+          })
+        ).size
+      ).toEqual(emberTemplateLintAddedCount);
+    });
   });
 
   describe('getTodoBatches', () => {

--- a/src/builders.ts
+++ b/src/builders.ts
@@ -4,6 +4,7 @@ import slash = require('slash');
 import { createHash } from 'crypto';
 import {
   DaysToDecay,
+  Engine,
   FilePath,
   GenericLintData,
   OperationType,
@@ -16,11 +17,18 @@ import TodoMatcher from './todo-matcher';
 
 const SEPARATOR = '|';
 
-export function buildFromTodoOperations(todoOperations: string[]): Map<FilePath, TodoMatcher> {
+export function buildFromTodoOperations(
+  todoOperations: string[],
+  engine: Engine
+): Map<FilePath, TodoMatcher> {
   const existingTodos = new Map<FilePath, TodoMatcher>();
 
   for (const todoOperation of todoOperations) {
     const [operation, todoDatum] = toTodoDatum(todoOperation);
+
+    if (todoDatum.engine !== engine) {
+      continue;
+    }
 
     if (!existingTodos.has(todoDatum.filePath)) {
       existingTodos.set(todoDatum.filePath, new TodoMatcher());

--- a/src/io.ts
+++ b/src/io.ts
@@ -204,7 +204,7 @@ export function readTodosForFilePath(
 }
 
 /**
- * Reads todo files in the .lint-todo directory and returns Todo data in an array.
+ * Reads todo files in the .lint-todo file and returns Todo data in an array.
  *
  * @param baseDir - The base directory that contains the .lint-todo storage file.
  * @param options - An object containing read options.

--- a/src/io.ts
+++ b/src/io.ts
@@ -11,6 +11,7 @@ import {
   WriteTodoOptions,
   Operation,
   OperationOrConflictLine,
+  ReadTodoOptions,
 } from './types';
 import TodoMatcher from './todo-matcher';
 import TodoBatchGenerator from './todo-batch-generator';
@@ -29,7 +30,7 @@ export function todoStorageFileExists(baseDir: string): boolean {
   try {
     return !lstatSync(getTodoStorageFilePath(baseDir)).isDirectory();
   } catch (error) {
-    if (error.code === 'ENOENT') {
+    if ((<any>error).code === 'ENOENT') {
       return false;
     }
 
@@ -118,7 +119,7 @@ export function writeTodoStorageFile(todoStorageFilePath: string, operations: Op
  * Given a list of todo lint violations, this function will also delete existing files that no longer
  * have a todo lint violation.
  *
- * @param baseDir - The base directory that contains the .lint-todo storage directory.
+ * @param baseDir - The base directory that contains the .lint-todo storage file.
  * @param maybeTodos - The linting data, converted to TodoData format.
  * @param options - An object containing write options.
  * @returns - The counts of added and removed todos.
@@ -126,7 +127,7 @@ export function writeTodoStorageFile(todoStorageFilePath: string, operations: Op
 export function writeTodos(
   baseDir: string,
   maybeTodos: Set<TodoData>,
-  options?: Partial<WriteTodoOptions>
+  options: WriteTodoOptions
 ): TodoBatchCounts {
   options = Object.assign({ shouldRemove: () => true, overwrite: false }, options);
 
@@ -137,8 +138,8 @@ export function writeTodos(
 
   try {
     const existing: Map<FilePath, TodoMatcher> = options.filePath
-      ? readTodosForFilePath(baseDir, options.filePath, false)
-      : readTodos(baseDir, false);
+      ? readTodosForFilePath(baseDir, options, false)
+      : readTodos(baseDir, options, false);
     batches = getTodoBatches(maybeTodos, existing, options);
 
     applyTodoChanges(baseDir, batches.add, batches.remove, false);
@@ -155,13 +156,18 @@ export function writeTodos(
 }
 
 /**
- * Reads all todo files in the .lint-todo directory.
+ * Reads all todo files in the .lint-todo file.
  *
- * @param baseDir - The base directory that contains the .lint-todo storage directory.
+ * @param baseDir - The base directory that contains the .lint-todo storage file.
+ * @param options - An object containing read options.
  * @param shouldLock - True if the .lint-todo storage file should be locked, otherwise false. Default: true.
  * @returns - A {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map|Map} of {@link https://github.com/lint-todo/utils/blob/master/src/types/todo.ts#L25|FilePath}/{@link https://github.com/lint-todo/utils/blob/master/src/todo-matcher.ts#L4|TodoMatcher}.
  */
-export function readTodos(baseDir: string, shouldLock = true): Map<FilePath, TodoMatcher> {
+export function readTodos(
+  baseDir: string,
+  options: ReadTodoOptions,
+  shouldLock = true
+): Map<FilePath, TodoMatcher> {
   const release =
     shouldLock && todoStorageFileExists(baseDir)
       ? tryLockStorageFile(baseDir)
@@ -171,43 +177,47 @@ export function readTodos(baseDir: string, shouldLock = true): Map<FilePath, Tod
   try {
     const todoOperations = readTodoStorageFile(getTodoStorageFilePath(baseDir));
 
-    return buildFromTodoOperations(todoOperations);
+    return buildFromTodoOperations(todoOperations, options.engine);
   } finally {
     release();
   }
 }
 
 /**
- * Reads todo files in the .lint-todo directory for a specific filePath.
+ * Reads todo files in the .lint-todo file for a specific filePath.
  *
- * @param todoStorageDir - The .lint-todo storage directory.
- * @param filePath - The relative file path of the file to return todo items for.
+ * @param baseDir - The base directory that contains the .lint-todo storage file.
+ * @param options - An object containing read options.
  * @param shouldLock - True if the .lint-todo storage file should be locked, otherwise false. Default: true.
  * @returns - A {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map|Map} of {@link https://github.com/lint-todo/utils/blob/master/src/types/todo.ts#L25|FilePath}/{@link https://github.com/lint-todo/utils/blob/master/src/todo-matcher.ts#L4|TodoMatcher}.
  */
 export function readTodosForFilePath(
   baseDir: string,
-  filePath: string,
+  options: ReadTodoOptions,
   shouldLock = true
 ): Map<FilePath, TodoMatcher> {
-  const existingTodos = readTodos(baseDir, shouldLock);
+  const existingTodos = readTodos(baseDir, options, shouldLock);
 
-  const matcher = existingTodos.get(filePath) || new TodoMatcher();
+  const matcher = existingTodos.get(options.filePath) || new TodoMatcher();
 
-  return new Map([[filePath, matcher]]);
+  return new Map([[options.filePath, matcher]]);
 }
 
 /**
  * Reads todo files in the .lint-todo directory and returns Todo data in an array.
  *
- * @param baseDir - The base directory that contains the .lint-todo storage directory.
+ * @param baseDir - The base directory that contains the .lint-todo storage file.
+ * @param options - An object containing read options.
  * @returns An array of {@link https://github.com/lint-todo/utils/blob/master/src/types/todo.ts#L61|TodoData}
  */
-export function readTodoData(baseDir: string): Set<TodoData> {
+export function readTodoData(baseDir: string, options: ReadTodoOptions): Set<TodoData> {
   return new Set(
-    [...readTodos(baseDir).values()].reduce((matcherResults: TodoData[], matcher: TodoMatcher) => {
-      return [...matcherResults, ...matcher.unprocessed];
-    }, [])
+    [...readTodos(baseDir, options).values()].reduce(
+      (matcherResults: TodoData[], matcher: TodoMatcher) => {
+        return [...matcherResults, ...matcher.unprocessed];
+      },
+      []
+    )
   );
 }
 
@@ -231,7 +241,7 @@ export function getTodoBatches(
 /**
  * Applies todo changes, either adding or removing, based on batches from `getTodoBatches`.
  *
- * @param baseDir - The base directory that contains the .lint-todo storage directory.
+ * @param baseDir - The base directory that contains the .lint-todo storage file.
  * @param add - Batch of todos to add.
  * @param remove - Batch of todos to remove.
  * @param shouldLock - True if the .lint-todo storage file should be locked, otherwise false. Default: true.
@@ -280,7 +290,7 @@ export const EXCLUDE_EXPIRED = (operation: Operation): boolean => {
 /**
  * Compacts the .lint-todo storage file based on the compact strategy.
  *
- * @param baseDir - The base directory that contains the .lint-todo storage directory.
+ * @param baseDir - The base directory that contains the .lint-todo storage file.
  * @param compactStrategy - The strategy to use when compacting the storage file. Default: ADD_OPERATIONS_ONLY
  * @returns The count of compacted todos.
  */
@@ -324,7 +334,7 @@ function tryLockStorageFile(baseDir: string, attempts = 0): () => void {
       throw error;
     }
 
-    if (error.code === 'ELOCKED') {
+    if ((<any>error).code === 'ELOCKED') {
       const start = Date.now();
       while (Date.now() - start < 500) {
         // artifical wait for other process to unlock file

--- a/src/types/todos.ts
+++ b/src/types/todos.ts
@@ -99,14 +99,27 @@ export interface TodoConfigByEngine {
 }
 
 /**
- * An optional configuration object passed to writeTodos.
+ * A configuration object passed to write todos.
  *
+ * @param engine - The engine that represents the lint too being used with todos.
  * @param filePath - The relative file path of the file to update violations for.
  * @param todoConfig - An object containing the warn or error days, in integers.
  * @param skipRemoval - Allows for skipping removal of todo files.
  */
 export interface WriteTodoOptions {
+  engine: Engine;
   filePath: string;
   todoConfig: TodoConfig;
   shouldRemove: (todoDatum: TodoData) => boolean;
+}
+
+/**
+ * A configuration object passed to read todos.
+ *
+ * @param engine - The engine that represents the lint too being used with todos.
+ * @param filePath - The relative file path of the file to update violations for.
+ */
+export interface ReadTodoOptions {
+  engine: Engine;
+  filePath: string;
 }


### PR DESCRIPTION
The current todos functionality does a reasonably good job of isolating operations between engines. However, during reads, and particularly for those reads that are part of external formatters, this functionality breaks down, as reads are not currently isolated by engines. This can result in inconsistent numbers for projects that are using both `eslint` and `ember-template-lint`, and are also using external formatters that read todo data for display/summarization.

This PR adds the requirement of adding an engine to the reads (via writes), and ensures that this read isolation is working correctly.