### PR TITLE
Adding new API: generateTodoBatches

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,11 @@ have a todo lint violation.</p>
 <dt><a href="#readTodoData">readTodoData(baseDir, options)</a> ⇒</dt>
 <dd><p>Reads todo files in the .lint-todo file and returns Todo data in an array.</p>
 </dd>
+<dt><a href="#generateTodoBatches">generateTodoBatches(baseDir, maybeTodos, options)</a> ⇒</dt>
+<dd><p>Gets 4 data structures containing todo items to add, remove, those that are expired, and those that are stable (not to be modified).</p>
+</dd>
 <dt><a href="#getTodoBatches">getTodoBatches(maybeTodos, existing, options)</a> ⇒</dt>
-<dd><p>Gets 4 maps containing todo items to add, remove, those that are expired, or those that are stable (not to be modified).</p>
+<dd><p>Gets 4 data structures containing todo items to add, remove, those that are expired, and those that are stable (not to be modified).</p>
 </dd>
 <dt><a href="#applyTodoChanges">applyTodoChanges(baseDir, add, remove, shouldLock)</a></dt>
 <dd><p>Applies todo changes, either adding or removing, based on batches from <code>getTodoBatches</code>.</p>
@@ -253,10 +256,24 @@ Reads todo files in the .lint-todo file and returns Todo data in an array.
 | baseDir | The base directory that contains the .lint-todo storage file. |
 | options | An object containing read options. |
 
+<a name="generateTodoBatches"></a>
+
+## generateTodoBatches(baseDir, maybeTodos, options) ⇒
+Gets 4 data structures containing todo items to add, remove, those that are expired, and those that are stable (not to be modified).
+
+**Kind**: global function  
+**Returns**: - An object of [TodoBatches](https://github.com/lint-todo/utils/blob/master/src/types/todo.ts#L36).  
+
+| Param | Description |
+| --- | --- |
+| baseDir | The base directory that contains the .lint-todo storage file. |
+| maybeTodos | The linting data for violations. |
+| options | An object containing write options. |
+
 <a name="getTodoBatches"></a>
 
 ## getTodoBatches(maybeTodos, existing, options) ⇒
-Gets 4 maps containing todo items to add, remove, those that are expired, or those that are stable (not to be modified).
+Gets 4 data structures containing todo items to add, remove, those that are expired, and those that are stable (not to be modified).
 
 **Kind**: global function  
 **Returns**: - An object of [TodoBatches](https://github.com/lint-todo/utils/blob/master/src/types/todo.ts#L36).  

--- a/__tests__/io-test.ts
+++ b/__tests__/io-test.ts
@@ -3,7 +3,6 @@ import { subDays } from 'date-fns';
 import {
   getDatePart,
   getTodoStorageFilePath,
-  getTodoBatches,
   todoStorageFileExists,
   readTodoData,
   readTodos,
@@ -31,6 +30,7 @@ import {
 import {
   compactTodoStorageFile,
   ensureTodoStorageFile,
+  getTodoBatches,
   hasConflicts,
   readTodoStorageFile,
   resolveConflicts,

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ export {
   compactTodoStorageFile,
   ensureTodoStorageFile,
   hasConflicts,
-  getTodoBatches,
+  generateTodoBatches,
   getTodoStorageFilePath,
   readTodos,
   readTodosForFilePath,

--- a/src/io.ts
+++ b/src/io.ts
@@ -222,7 +222,25 @@ export function readTodoData(baseDir: string, options: ReadTodoOptions): Set<Tod
 }
 
 /**
- * Gets 4 maps containing todo items to add, remove, those that are expired, or those that are stable (not to be modified).
+ * Gets 4 data structures containing todo items to add, remove, those that are expired, and those that are stable (not to be modified).
+ *
+ * @param baseDir - The base directory that contains the .lint-todo storage file.
+ * @param maybeTodos - The linting data for violations.
+ * @param options - An object containing write options.
+ * @returns - An object of {@link https://github.com/lint-todo/utils/blob/master/src/types/todo.ts#L36|TodoBatches}.
+ */
+export function generateTodoBatches(
+  baseDir: string,
+  maybeTodos: Set<TodoData>,
+  options: Partial<WriteTodoOptions>
+): TodoBatches {
+  const existingTodos = readTodosForFilePath(baseDir, options as ReadTodoOptions);
+
+  return getTodoBatches(maybeTodos, existingTodos, options);
+}
+
+/**
+ * Gets 4 data structures containing todo items to add, remove, those that are expired, and those that are stable (not to be modified).
  *
  * @param maybeTodos - The linting data for violations.
  * @param existing - Existing todo lint data.


### PR DESCRIPTION
The `getTodoBatches` and `readTodosForFilePath` functions are always used in conjunction to generate the batches. In order to simplify for consumers what they need to call in order to generate batches, this PR adds a new higher-level API that combines some of the lower-level functions.