### PR TITLE
Fixes todos not correctly matching up when using non-normalized relative paths

### DIFF
--- a/__tests__/__fixtures__/single-file-errors.json
+++ b/__tests__/__fixtures__/single-file-errors.json
@@ -1,0 +1,45 @@
+[
+  {
+    "filePath": "{{path}}/app/controllers/settings.js",
+    "messages": [
+      {
+        "ruleId": "no-prototype-builtins",
+        "severity": 2,
+        "message": "Do not access Object.prototype method 'hasOwnProperty' from target object.",
+        "line": 25,
+        "column": 21,
+        "nodeType": "CallExpression",
+        "messageId": "prototypeBuildIn",
+        "endLine": 25,
+        "endColumn": 35
+      },
+      {
+        "ruleId": "no-prototype-builtins",
+        "severity": 2,
+        "message": "Do not access Object.prototype method 'hasOwnProperty' from target object.",
+        "line": 26,
+        "column": 19,
+        "nodeType": "CallExpression",
+        "messageId": "prototypeBuildIn",
+        "endLine": 26,
+        "endColumn": 33
+      },
+      {
+        "ruleId": "no-prototype-builtins",
+        "severity": 2,
+        "message": "Do not access Object.prototype method 'hasOwnProperty' from target object.",
+        "line": 32,
+        "column": 34,
+        "nodeType": "CallExpression",
+        "messageId": "prototypeBuildIn",
+        "endLine": 32,
+        "endColumn": 48
+      }
+    ],
+    "errorCount": 3,
+    "warningCount": 0,
+    "fixableErrorCount": 0,
+    "fixableWarningCount": 0,
+    "source": ""
+  }
+]

--- a/__tests__/__utils__/update-path.ts
+++ b/__tests__/__utils__/update-path.ts
@@ -1,5 +1,7 @@
+import { normalize } from 'path';
+
 export function updatePaths<T extends { filePath: string }>(path: string, data: T[]): T[] {
-  data.forEach((d) => (d.filePath = d.filePath.replace('{{path}}', path)));
+  data.forEach((d) => (d.filePath = normalize(d.filePath.replace('{{path}}', path))));
 
   return data;
 }
@@ -7,7 +9,7 @@ export function updatePaths<T extends { filePath: string }>(path: string, data: 
 export function updatePath<T extends { filePath: string }>(path: string, data: T): T {
   const newData = { ...data };
 
-  newData.filePath = newData.filePath.replace('{{path}}', path);
+  newData.filePath = normalize(newData.filePath.replace('{{path}}', path));
 
   return newData;
 }

--- a/__tests__/__utils__/update-path.ts
+++ b/__tests__/__utils__/update-path.ts
@@ -1,4 +1,4 @@
-import { normalize } from 'path';
+import { normalize } from 'upath';
 
 export function updatePaths<T extends { filePath: string }>(path: string, data: T[]): T[] {
   data.forEach((d) => (d.filePath = normalize(d.filePath.replace('{{path}}', path))));

--- a/__tests__/io-test.ts
+++ b/__tests__/io-test.ts
@@ -32,6 +32,7 @@ import {
   ensureTodoStorageFile,
   getTodoBatches,
   hasConflicts,
+  readTodoDataForFilePath,
   readTodoStorageFile,
   resolveConflicts,
   writeTodoStorageFile,
@@ -346,7 +347,16 @@ remove|eslint|no-unused-vars|30|19|30|33|da39a3ee5e6b4b0d3255bfef95601890afd8070
       );
 
       expect(addedCount).toEqual(3);
-      expect(stableTodoFragment(readTodoData(tmp, buildReadOptions()))).toMatchInlineSnapshot(`
+      expect(
+        stableTodoFragment(
+          readTodoDataForFilePath(
+            tmp,
+            buildReadOptions({
+              filePath: 'app/controllers/settings.js',
+            })
+          )
+        )
+      ).toMatchInlineSnapshot(`
         Array [
           Object {
             "filePath": "app/controllers/settings.js",
@@ -404,7 +414,16 @@ remove|eslint|no-unused-vars|30|19|30|33|da39a3ee5e6b4b0d3255bfef95601890afd8070
       );
 
       expect(addedCount).toEqual(3);
-      expect(stableTodoFragment(readTodoData(tmp, buildReadOptions()))).toMatchInlineSnapshot(`
+      expect(
+        stableTodoFragment(
+          readTodoDataForFilePath(
+            tmp,
+            buildReadOptions({
+              filePath: 'app/controllers/settings.js',
+            })
+          )
+        )
+      ).toMatchInlineSnapshot(`
         Array [
           Object {
             "filePath": "app/controllers/settings.js",
@@ -465,7 +484,16 @@ remove|eslint|no-unused-vars|30|19|30|33|da39a3ee5e6b4b0d3255bfef95601890afd8070
         removedCount: 1,
         stableCount: 2,
       });
-      expect(stableTodoFragment(readTodoData(tmp, buildReadOptions()))).toMatchInlineSnapshot(`
+      expect(
+        stableTodoFragment(
+          readTodoDataForFilePath(
+            tmp,
+            buildReadOptions({
+              filePath: 'app/controllers/settings.js',
+            })
+          )
+        )
+      ).toMatchInlineSnapshot(`
         Array [
           Object {
             "filePath": "app/controllers/settings.js",
@@ -523,7 +551,16 @@ remove|eslint|no-unused-vars|30|19|30|33|da39a3ee5e6b4b0d3255bfef95601890afd8070
       );
 
       expect(addedCount).toEqual(3);
-      expect(stableTodoFragment(readTodoData(tmp, buildReadOptions()))).toMatchInlineSnapshot(`
+      expect(
+        stableTodoFragment(
+          readTodoDataForFilePath(
+            tmp,
+            buildReadOptions({
+              filePath: 'app/controllers/settings.js',
+            })
+          )
+        )
+      ).toMatchInlineSnapshot(`
         Array [
           Object {
             "filePath": "app/controllers/settings.js",
@@ -580,7 +617,14 @@ remove|eslint|no-unused-vars|30|19|30|33|da39a3ee5e6b4b0d3255bfef95601890afd8070
 
       expect(addedCount2).toEqual(0);
       expect(removedCount).toEqual(3);
-      expect(readTodoData(tmp, buildReadOptions()).size).toEqual(0);
+      expect(
+        readTodoDataForFilePath(
+          tmp,
+          buildReadOptions({
+            filePath: 'app/controllers/settings.js',
+          })
+        ).size
+      ).toEqual(0);
     });
   });
 
@@ -643,6 +687,105 @@ remove|eslint|no-unused-vars|30|19|30|33|da39a3ee5e6b4b0d3255bfef95601890afd8070
           })
         ).size
       ).toEqual(emberTemplateLintAddedCount);
+    });
+  });
+
+  describe('readTodosForFilePath', () => {
+    it('can read empty storage file', () => {
+      writeTodos(tmp, new Set(), buildWriteOptions(tmp));
+
+      expect(
+        readTodos(
+          tmp,
+          buildReadOptions({
+            filePath: '/app/controllers/settings.js',
+          })
+        ).size
+      ).toEqual(0);
+    });
+
+    it('can read storage file with adds only', () => {
+      const initialTodos = buildMaybeTodosFromFixture(tmp, 'single-file-errors');
+      const { addedCount } = writeTodos(
+        tmp,
+        initialTodos,
+        buildWriteOptions(tmp, {
+          filePath: 'app/controllers/settings.js',
+        })
+      );
+      expect(addedCount).toEqual(3);
+
+      expect(
+        readTodoDataForFilePath(
+          tmp,
+          buildReadOptions({
+            filePath: 'app/controllers/settings.js',
+          })
+        ).size
+      ).toEqual(addedCount);
+    });
+
+    it('can read todos with non-normalized filePath', () => {
+      const initialTodos = buildMaybeTodosFromFixture(tmp, 'single-file-errors');
+      const { addedCount } = writeTodos(
+        tmp,
+        initialTodos,
+        buildWriteOptions(tmp, {
+          filePath: './app/controllers/settings.js',
+        })
+      );
+      expect(addedCount).toEqual(3);
+
+      expect(
+        readTodoDataForFilePath(
+          tmp,
+          buildReadOptions({
+            filePath: './app/controllers/settings.js',
+          })
+        ).size
+      ).toEqual(addedCount);
+    });
+
+    it('can read storage file with adds and removes', () => {
+      const initialTodos = buildMaybeTodosFromFixture(tmp, 'single-file-errors');
+      const { addedCount } = writeTodos(
+        tmp,
+        initialTodos,
+        buildWriteOptions(tmp, {
+          filePath: 'app/controllers/settings.js',
+        })
+      );
+
+      expect(
+        readTodoData(
+          tmp,
+          buildReadOptions({
+            filePath: 'app/controllers/settings.js',
+          })
+        ).size
+      ).toEqual(addedCount);
+
+      const [firstChunk] = chunk(initialTodos, 2);
+
+      const { removedCount } = writeTodos(
+        tmp,
+        firstChunk,
+        buildWriteOptions(tmp, {
+          filePath: 'app/controllers/settings.js',
+        })
+      );
+
+      expect(readTodoStorageFile(getTodoStorageFilePath(tmp))).toHaveLength(
+        addedCount + removedCount
+      );
+      expect(
+        readTodoData(
+          tmp,
+          buildReadOptions({
+            filePath: 'app/controllers/settings.js',
+          })
+        ).size
+      ).toEqual(2);
     });
   });
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "fs-extra": "^9.1.0",
     "proper-lockfile": "^4.1.2",
     "slash": "^3.0.0",
-    "tslib": "^2.3.1"
+    "tslib": "^2.3.1",
+    "upath": "^2.0.1"
   },
   "devDependencies": {
     "@scalvert/readme-api-generator": "^0.1.0",

--- a/src/builders.ts
+++ b/src/builders.ts
@@ -1,4 +1,4 @@
-import { isAbsolute, relative } from 'path';
+import { isAbsolute, relative, normalize } from 'path';
 import { EOL } from 'os';
 import slash = require('slash');
 import { createHash } from 'crypto';
@@ -143,11 +143,9 @@ export function buildTodoDatum(
   genericLintData: GenericLintData,
   todoConfig?: TodoConfig
 ): TodoData {
-  // Note: If https://github.com/nodejs/node/issues/13683 is fixed, remove slash() and use posix.relative
-  // provided that the fix is landed on the supported node versions of this lib
   const filePath = isAbsolute(genericLintData.filePath)
     ? relative(baseDir, genericLintData.filePath)
-    : genericLintData.filePath;
+    : normalize(genericLintData.filePath);
   const todoDatum: TodoData = Object.assign(
     genericLintData,
     {

--- a/src/builders.ts
+++ b/src/builders.ts
@@ -1,4 +1,4 @@
-import { isAbsolute, relative, normalize } from 'path';
+import { isAbsolute, relative, normalize } from 'upath';
 import { EOL } from 'os';
 import slash = require('slash');
 import { createHash } from 'crypto';

--- a/src/io.ts
+++ b/src/io.ts
@@ -1,4 +1,5 @@
-import { join, normalize } from 'path';
+import { join } from 'path';
+import { normalize } from 'upath';
 import { EOL } from 'os';
 import { lockSync } from 'proper-lockfile';
 import { readFileSync, appendFileSync, writeFileSync, ensureFileSync, lstatSync } from 'fs-extra';

--- a/yarn.lock
+++ b/yarn.lock
@@ -7173,6 +7173,11 @@ unset-value@^1.0.0:
     has-value "^0.3.1"
     isobject "^3.0.0"
 
+upath@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/upath/-/upath-2.0.1.tgz#50c73dea68d6f6b990f51d279ce6081665d61a8b"
+  integrity sha512-1uEe95xksV1O0CYKXo8vQvN1JEbtJp7lb7C5U9HMsIp6IVwntkH/oNUzyVNQSd4S1sYk2FpSSW44FqMc8qee5w==
+
 update-notifier@5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/update-notifier/-/update-notifier-5.1.0.tgz#4ab0d7c7f36a231dd7316cf7729313f0214d9ad9"


### PR DESCRIPTION
Fixes https://github.com/ember-template-lint/ember-template-lint/issues/2287