### PR TITLE
Fix compacting to not be destructive with other engines

### DIFF
--- a/src/builders.ts
+++ b/src/builders.ts
@@ -26,7 +26,7 @@ export function buildFromTodoOperations(
   for (const todoOperation of todoOperations) {
     const [operation, todoDatum] = toTodoDatum(todoOperation);
 
-    if (todoDatum.engine !== engine) {
+    if (engine !== 'all' && todoDatum.engine !== engine) {
       continue;
     }
 

--- a/src/io.ts
+++ b/src/io.ts
@@ -308,19 +308,18 @@ export function applyTodoChanges(
  * Compacts the .lint-todo storage file.
  *
  * @param baseDir - The base directory that contains the .lint-todo storage file.
- * @param options - An object containing read options.
  * @returns The count of compacted todos.
  */
-export function compactTodoStorageFile(
-  baseDir: string,
-  options: ReadTodoOptions
-): {
+export function compactTodoStorageFile(baseDir: string): {
   originalOperations: Operation[];
   compactedOperations: Operation[];
   compacted: number;
 } {
   const todoStorageFilePath = getTodoStorageFilePath(baseDir);
-  const todos = readTodoData(baseDir, options);
+  const todos = readTodoData(baseDir, {
+    engine: 'all',
+    filePath: '',
+  });
   const release = tryLockStorageFile(baseDir);
 
   try {

--- a/src/types/todos.ts
+++ b/src/types/todos.ts
@@ -31,7 +31,7 @@ export type TodoBatches = {
   remove: Set<TodoData>;
 };
 
-export type Engine = 'eslint' | 'ember-template-lint' | string;
+export type Engine = 'all' | 'eslint' | 'ember-template-lint' | string;
 export type OperationType = 'add' | 'remove';
 export type Operation =
   `${OperationType}|${Engine}|${string}|${number}|${number}|${number}|${number}|${string}|${

--- a/tests/io-test.ts
+++ b/tests/io-test.ts
@@ -129,7 +129,7 @@ describe('io', () => {
 
       writeTodoStorageFile(todoStorageFilePath, [...addOperations, ...removeOperations]);
 
-      compactTodoStorageFile(tmp, buildReadOptions());
+      compactTodoStorageFile(tmp);
 
       expect(readTodoStorageFile(todoStorageFilePath)).toEqual([]);
     });
@@ -147,11 +147,37 @@ describe('io', () => {
 
       writeTodoStorageFile(todoStorageFilePath, operations);
 
-      compactTodoStorageFile(tmp, buildReadOptions());
+      compactTodoStorageFile(tmp);
 
       expect(readTodoStorageFile(todoStorageFilePath)).toEqual([
         'add|eslint|no-prototype-builtins|65|27|65|41|da39a3ee5e6b4b0d3255bfef95601890afd80709|1637107200000|||tests/unit/services/insights-test.js',
         'add|eslint|no-prototype-builtins|80|27|80|41|da39a3ee5e6b4b0d3255bfef95601890afd80709|1637107200000|||tests/unit/services/insights-test.js',
+      ]);
+    });
+
+    it('compacts respects multiple co-existing engines', () => {
+      const todoStorageFilePath = getTodoStorageFilePath(tmp);
+      const operations: Operation[] = [
+        'add|eslint|no-prototype-builtins|25|21|25|35|da39a3ee5e6b4b0d3255bfef95601890afd80709|1637107200000|||app/controllers/settings.js',
+        'add|eslint|no-prototype-builtins|30|21|25|35|da39a3ee5e6b4b0d3255bfef95601890afd80709|1637107200000|||app/controllers/settings.js',
+        'add|ember-template-lint|no-html-comments|26|19|26|33|da39a3ee5e6b4b0d3255bfef95601890afd80709|1637107200000|||app/templates/settings.hbs',
+        'remove|eslint|no-prototype-builtins|25|21|25|35|da39a3ee5e6b4b0d3255bfef95601890afd80709|1637107200000|||app/controllers/settings.js',
+        'add|eslint|no-prototype-builtins|65|27|65|41|da39a3ee5e6b4b0d3255bfef95601890afd80709|1637107200000|||tests/unit/services/insights-test.js',
+        'add|eslint|no-prototype-builtins|90|27|65|41|da39a3ee5e6b4b0d3255bfef95601890afd80709|1637107200000|||tests/unit/services/insights-test.js',
+        'add|ember-template-lint|no-html-comments|80|27|80|41|da39a3ee5e6b4b0d3255bfef95601890afd80709|1637107200000|||app/templates/insights.hbs',
+        'remove|eslint|no-prototype-builtins|26|19|26|33|da39a3ee5e6b4b0d3255bfef95601890afd80709|1637107200000|||app/controllers/settings.js',
+      ];
+
+      writeTodoStorageFile(todoStorageFilePath, operations);
+
+      compactTodoStorageFile(tmp);
+
+      expect(readTodoStorageFile(todoStorageFilePath)).toEqual([
+        'add|eslint|no-prototype-builtins|30|21|25|35|da39a3ee5e6b4b0d3255bfef95601890afd80709|1637107200000|||app/controllers/settings.js',
+        'add|ember-template-lint|no-html-comments|26|19|26|33|da39a3ee5e6b4b0d3255bfef95601890afd80709|1637107200000|||app/templates/settings.hbs',
+        'add|eslint|no-prototype-builtins|65|27|65|41|da39a3ee5e6b4b0d3255bfef95601890afd80709|1637107200000|||tests/unit/services/insights-test.js',
+        'add|eslint|no-prototype-builtins|90|27|65|41|da39a3ee5e6b4b0d3255bfef95601890afd80709|1637107200000|||tests/unit/services/insights-test.js',
+        'add|ember-template-lint|no-html-comments|80|27|80|41|da39a3ee5e6b4b0d3255bfef95601890afd80709|1637107200000|||app/templates/insights.hbs',
       ]);
     });
   });


### PR DESCRIPTION
Let's try this again...

Fixing compacting to not eagerly delete other engine's entries in the `.lint-todo` file.