### PR TITLE
Adding utils to read and extract source fragments

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Those utilities are:
 
 <dl>
 <dt><a href="#buildTodoDatum">buildTodoDatum(lintResult, lintMessage, todoConfig)</a> ⇒</dt>
-<dd><p>Adapts a <a href="https://github.com/lint-todo/utils/blob/master/src/types/lint.ts#L31">LintResult</a> to a <a href="https://github.com/lint-todo/utils/blob/master/src/types/todos.ts#L46">TodoData</a>. FilePaths are absolute
+<dd><p>Adapts a <a href="https://github.com/lint-todo/utils/blob/master/src/types/lint.ts#L31">LintResult</a> to a <a href="https://github.com/lint-todo/utils/blob/master/src/types/todo.ts#L61">TodoData</a>. FilePaths are absolute
 when received from a lint result, so they&#39;re converted to relative paths for stability in
 serializing the contents to disc.</p>
 </dd>
@@ -68,7 +68,7 @@ have a todo lint violation.</p>
 <dt><a href="#applyTodoChanges">applyTodoChanges(baseDir, add, remove, shouldLock)</a></dt>
 <dd><p>Applies todo changes, either adding or removing, based on batches from <code>getTodoBatches</code>.</p>
 </dd>
-<dt><a href="#compactTodoStorageFile">compactTodoStorageFile(baseDir, options)</a> ⇒</dt>
+<dt><a href="#compactTodoStorageFile">compactTodoStorageFile(baseDir)</a> ⇒</dt>
 <dd><p>Compacts the .lint-todo storage file.</p>
 </dd>
 <dt><a href="#getTodoConfig">getTodoConfig(baseDir, engine, customDaysToDecay)</a> ⇒</dt>
@@ -91,6 +91,15 @@ have a todo lint violation.</p>
 </dd>
 <dt><a href="#format">format(date)</a> ⇒</dt>
 <dd><p>Formats the date in short form, eg. 2021-01-01</p>
+</dd>
+<dt><a href="#buildRange">buildRange(line, column, endLine, endColumn)</a> ⇒</dt>
+<dd><p>Converts node positional numbers into a Range object.</p>
+</dd>
+<dt><a href="#readSource">readSource(filePath)</a> ⇒</dt>
+<dd><p>Reads a source file, optionally caching it if it&#39;s already been read.</p>
+</dd>
+<dt><a href="#getSourceForRange">getSourceForRange(source, range)</a> ⇒</dt>
+<dd><p>Extracts a source fragment from a file&#39;s contents based on the provided Range.</p>
 </dd>
 </dl>
 
@@ -308,7 +317,7 @@ Applies todo changes, either adding or removing, based on batches from `getTodoB
 
 <a name="compactTodoStorageFile"></a>
 
-## compactTodoStorageFile(baseDir, options) ⇒
+## compactTodoStorageFile(baseDir) ⇒
 Compacts the .lint-todo storage file.
 
 **Kind**: global function  
@@ -317,7 +326,6 @@ Compacts the .lint-todo storage file.
 | Param | Description |
 | --- | --- |
 | baseDir | The base directory that contains the .lint-todo storage file. |
-| options | An object containing read options. |
 
 <a name="getTodoConfig"></a>
 
@@ -449,6 +457,46 @@ Formats the date in short form, eg. 2021-01-01
 | Param | Description |
 | --- | --- |
 | date | The date to format |
+
+<a name="buildRange"></a>
+
+## buildRange(line, column, endLine, endColumn) ⇒
+Converts node positional numbers into a Range object.
+
+**Kind**: global function  
+**Returns**: A range object.  
+
+| Param | Description |
+| --- | --- |
+| line | The source start line. |
+| column | The source start column. |
+| endLine | The source end line. |
+| endColumn | The source end column. |
+
+<a name="readSource"></a>
+
+## readSource(filePath) ⇒
+Reads a source file, optionally caching it if it's already been read.
+
+**Kind**: global function  
+**Returns**: The file contents.  
+
+| Param | Description |
+| --- | --- |
+| filePath | The path to the source file. |
+
+<a name="getSourceForRange"></a>
+
+## getSourceForRange(source, range) ⇒
+Extracts a source fragment from a file's contents based on the provided Range.
+
+**Kind**: global function  
+**Returns**: The source fragment.  
+
+| Param | Description |
+| --- | --- |
+| source | The file contents. |
+| range | A Range object representing the range to extract from the file contents. |
 
 
 <!--DOCS_END-->

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build": "tsc --build",
     "build:watch": "tsc --watch",
     "clean": "tsc --build --clean",
-    "docs:update": "npm run build && readme-api-generator lib/builders.js lib/io.js lib/todo-config.js lib/get-severity.js lib/date-utils.js",
+    "docs:update": "npm run build && readme-api-generator lib/builders.js lib/io.js lib/todo-config.js lib/get-severity.js lib/date-utils.js lib/source.js",
     "lint": "eslint . --ext .ts",
     "prepare": "npm run build",
     "test": "npm-run-all lint test:*",

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,5 +18,6 @@ export {
 export { getTodoConfig, validateConfig } from './todo-config';
 export { getSeverity } from './get-severity';
 export { differenceInDays, format, getDatePart, isExpired } from './date-utils';
+export { readSource, getSourceForRange } from './source';
 
 export * from './types';

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,6 @@ export {
 export { getTodoConfig, validateConfig } from './todo-config';
 export { getSeverity } from './get-severity';
 export { differenceInDays, format, getDatePart, isExpired } from './date-utils';
-export { readSource, getSourceForRange } from './source';
+export { buildRange, readSource, getSourceForRange } from './source';
 
 export * from './types';

--- a/src/source.ts
+++ b/src/source.ts
@@ -4,7 +4,21 @@ import { Range } from './types';
 const LINES_PATTERN = /(.*?(?:\r\n?|\n|$))/gm;
 export const _sourceCache = new Map<string, string>();
 
-export function buildRange(line: number, column: number, endLine?: number, endColumn?: number) {
+/**
+ * Converts node positional numbers into a Range object.
+ *
+ * @param line - The source start line.
+ * @param column - The source start column.
+ * @param endLine - The source end line.
+ * @param endColumn - The source end column.
+ * @returns A range object.
+ */
+export function buildRange(
+  line: number,
+  column: number,
+  endLine?: number,
+  endColumn?: number
+): Range {
   return {
     start: {
       line: line,
@@ -17,7 +31,13 @@ export function buildRange(line: number, column: number, endLine?: number, endCo
   };
 }
 
-export function readSource(filePath: string | undefined) {
+/**
+ * Reads a source file, optionally caching it if it's already been read.
+ *
+ * @param filePath - The path to the source file.
+ * @returns The file contents.
+ */
+export function readSource(filePath: string | undefined): string {
   if (!filePath) {
     return '';
   }
@@ -31,7 +51,14 @@ export function readSource(filePath: string | undefined) {
   return _sourceCache.get(filePath) || '';
 }
 
-export function getSourceForRange(source: string, range: Range) {
+/**
+ * Extracts a source fragment from a file's contents based on the provided Range.
+ *
+ * @param source - The file contents.
+ * @param range - A Range object representing the range to extract from the file contents.
+ * @returns The source fragment.
+ */
+export function getSourceForRange(source: string, range: Range): string {
   if (!source) {
     return '';
   }

--- a/src/source.ts
+++ b/src/source.ts
@@ -1,0 +1,66 @@
+import { existsSync, readFileSync } from 'fs';
+import { Range } from './types';
+
+const LINES_PATTERN = /(.*?(?:\r\n?|\n|$))/gm;
+export const _sourceCache = new Map<string, string>();
+
+export function buildRange(line: number, column: number, endLine?: number, endColumn?: number) {
+  return {
+    start: {
+      line: line,
+      column: column,
+    },
+    end: {
+      line: endLine ?? line,
+      column: endColumn ?? column,
+    },
+  };
+}
+
+export function readSource(filePath: string | undefined) {
+  if (!filePath) {
+    return '';
+  }
+
+  if (existsSync(filePath) && !_sourceCache.has(filePath)) {
+    const source = readFileSync(filePath, { encoding: 'utf8' });
+
+    _sourceCache.set(filePath, source);
+  }
+
+  return _sourceCache.get(filePath) || '';
+}
+
+export function getSourceForRange(source: string, range: Range) {
+  if (!source) {
+    return '';
+  }
+
+  const sourceLines = source.match(LINES_PATTERN) || [];
+  const firstLine = range.start.line - 1;
+  const lastLine = range.end.line - 1;
+  let currentLine = firstLine - 1;
+  const firstColumn = range.start.column - 1;
+  const lastColumn = range.end.column - 1;
+  const src = [];
+  let line;
+
+  while (currentLine < lastLine) {
+    currentLine++;
+    line = sourceLines[currentLine];
+
+    if (currentLine === firstLine) {
+      if (firstLine === lastLine) {
+        src.push(line.slice(firstColumn, lastColumn));
+      } else {
+        src.push(line.slice(firstColumn));
+      }
+    } else if (currentLine === lastLine) {
+      src.push(line.slice(0, lastColumn));
+    } else {
+      src.push(line);
+    }
+  }
+
+  return src.join('');
+}

--- a/tests/source-test.ts
+++ b/tests/source-test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { buildRange, getSourceForRange } from '../src/source';
+
+describe('source', () => {
+  describe('getSourceForRange', () => {
+    it('returns empty string for empty source', () => {
+      expect(getSourceForRange('', buildRange(0, 0))).toEqual('');
+    });
+
+    it('returns correct full single line fragment', () => {
+      const source = "const someLongVariableDeclaration = 'This is a message!!'";
+      const range = buildRange(1, 1, 1, 58);
+
+      expect(getSourceForRange(source, range)).toEqual(source);
+    });
+
+    it('returns correct single line sub-fragment', () => {
+      const source = "const someLongVariableDeclaration = 'This is a message!!'";
+      const range = buildRange(1, 1, 1, 34);
+
+      expect(getSourceForRange(source, range)).toEqual('const someLongVariableDeclaration');
+    });
+
+    it('returns correct multi line sub-fragment', () => {
+      const source = `function addOne(i) {
+  if (i != NaN) {
+    return i++;
+  }
+  return;
+}`;
+
+      expect(getSourceForRange(source, buildRange(1, 10, 1, 16))).toEqual('addOne');
+      expect(getSourceForRange(source, buildRange(2, 7, 2, 15))).toEqual('i != NaN');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds 3 new utils for extracting source file contents and fragments from the underlying source files. This is useful for consumers who are integrating todos into third-party tools that have no source extracted as part of their returned results.

Source fragments are a necessary part of the fuzzy matching algorithm, where we attempt to run matches to identify todos.