### PR TITLE
Fix compact todo EOL issues, add more tests

### DIFF
--- a/src/builders.ts
+++ b/src/builders.ts
@@ -18,7 +18,7 @@ import TodoMatcher from './todo-matcher';
 const SEPARATOR = '|';
 
 export function buildFromTodoOperations(
-  todoOperations: string[],
+  todoOperations: Operation[],
   engine: Engine
 ): Map<FilePath, TodoMatcher> {
   const existingTodos = new Map<FilePath, TodoMatcher>();
@@ -66,7 +66,7 @@ export function buildTodoOperations(add: Set<TodoData>, remove: Set<TodoData>): 
   return ops as Operation[];
 }
 
-export function toTodoDatum(todoOperation: string): [OperationType, TodoData] {
+export function toTodoDatum(todoOperation: Operation): [OperationType, TodoData] {
   const [
     operation,
     engine,

--- a/src/io.ts
+++ b/src/io.ts
@@ -114,6 +114,16 @@ export function writeTodoStorageFile(todoStorageFilePath: string, operations: Op
 }
 
 /**
+ * Appends the operations to the .lint-todo storage file to the path provided by the todoStorageFilePath
+ *
+ * @param todoStorageFilePath - The .lint-todo storage file path.
+ * @param operations - An array of string operations that are used to recreate todos.
+ */
+export function appendTodoStorageFile(todoStorageFilePath: string, operations: Operation[]): void {
+  appendFileSync(todoStorageFilePath, operations.join(EOL) + EOL);
+}
+
+/**
  * Writes files for todo lint violations. One file is generated for each violation, using a generated
  * hash to identify each.
  *
@@ -303,7 +313,7 @@ export function applyTodoChanges(
   }
 
   try {
-    appendFileSync(todoStorageFilePath, ops.join(EOL) + EOL);
+    appendTodoStorageFile(todoStorageFilePath, ops)
   } finally {
     release();
   }

--- a/src/io.ts
+++ b/src/io.ts
@@ -92,7 +92,7 @@ export function readTodoStorageFile(todoStorageFilePath: string): Operation[] {
   });
 
   // when splitting by EOL, make sure to filter off the '' caused by the final EOL
-  let operations: OperationOrConflictLine[] = todoContents.split(EOL).filter((op: OperationOrConflictLine | '') => op !== '')
+  let operations = todoContents.split(EOL).filter((op: string) => op !== '') as OperationOrConflictLine[]
 
   if (hasConflicts(todoContents)) {
     operations = resolveConflicts(operations);

--- a/src/io.ts
+++ b/src/io.ts
@@ -100,7 +100,7 @@ export function readTodoStorageFile(todoStorageFilePath: string): Operation[] {
     writeTodoStorageFile(todoStorageFilePath, operations as Operation[]);
   }
 
-  return operations.filter(Boolean) as Operation[];
+  return operations as Operation[];
 }
 
 /**

--- a/src/io.ts
+++ b/src/io.ts
@@ -91,7 +91,8 @@ export function readTodoStorageFile(todoStorageFilePath: string): Operation[] {
     encoding: 'utf8',
   });
 
-  let operations = todoContents.split(EOL) as OperationOrConflictLine[];
+  // when splitting by EOL, make sure to filter off the '' caused by the final EOL
+  let operations: OperationOrConflictLine[] = todoContents.split(EOL).filter((op: OperationOrConflictLine | '') => op !== '')
 
   if (hasConflicts(todoContents)) {
     operations = resolveConflicts(operations);
@@ -109,7 +110,7 @@ export function readTodoStorageFile(todoStorageFilePath: string): Operation[] {
  * @param operations - An array of string operations that are used to recreate todos.
  */
 export function writeTodoStorageFile(todoStorageFilePath: string, operations: Operation[]): void {
-  writeFileSync(todoStorageFilePath, operations.join(EOL));
+  writeFileSync(todoStorageFilePath, operations.join(EOL) + EOL);
 }
 
 /**

--- a/tests/builders-test.ts
+++ b/tests/builders-test.ts
@@ -3,6 +3,7 @@ import { describe, beforeEach, it, expect } from 'vitest';
 import { differenceInDays } from 'date-fns';
 import { getDatePart } from '../src/date-utils';
 import { buildFromTodoOperations, buildTodoDatum, buildTodoOperations } from '../src/builders';
+import { Operation } from '../src/types';
 import { createTmpDir } from './utils/tmp-dir';
 import { buildMaybeTodosFromFixture } from './utils/build-todo-data';
 
@@ -225,7 +226,7 @@ describe('builders', () => {
 
   describe('buildFromOperations', () => {
     it('builds single todo from single add', () => {
-      const todoOperations: string[] = [
+      const todoOperations: Operation[] = [
         'add|ember-template-lint|no-implicit-this|174|8|174|8|864e3ef2438ac413d96a032cdd141e567fcc04b3|1629331200000|2493248400000|2493334800000|addon/templates/components/foo.hbs',
       ];
 
@@ -262,7 +263,7 @@ describe('builders', () => {
     });
 
     it('builds single todo from single add with pipes in filePath', () => {
-      const todoOperations: string[] = [
+      const todoOperations: Operation[] = [
         'add|ember-template-lint|no-implicit-this|174|8|174|8|864e3ef2438ac413d96a032cdd141e567fcc04b3|1629331200000|2493248400000|2493334800000|addon/templates/components/fo|o.hbs',
       ];
 
@@ -299,7 +300,7 @@ describe('builders', () => {
     });
 
     it('builds single todo from multiple identical adds', () => {
-      const todoOperations: string[] = [
+      const todoOperations: Operation[] = [
         'add|ember-template-lint|no-implicit-this|174|8|174|8|864e3ef2438ac413d96a032cdd141e567fcc04b3|1629331200000|2493248400000|2493334800000|addon/templates/components/foo.hbs',
         'add|ember-template-lint|no-implicit-this|174|8|174|8|864e3ef2438ac413d96a032cdd141e567fcc04b3|1629331200000|2493248400000|2493334800000|addon/templates/components/foo.hbs',
       ];
@@ -334,7 +335,7 @@ describe('builders', () => {
     });
 
     it('builds empty todos from single add and remove', () => {
-      const todoOperations: string[] = [
+      const todoOperations: Operation[] = [
         'add|ember-template-lint|no-implicit-this|174|8|174|8|864e3ef2438ac413d96a032cdd141e567fcc04b3|1629331200000|2493248400000|2493334800000|addon/templates/components/foo.hbs',
         'remove|ember-template-lint|no-implicit-this|174|8|174|8|864e3ef2438ac413d96a032cdd141e567fcc04b3|1629331200000|2493248400000|2493334800000|addon/templates/components/foo.hbs',
       ];
@@ -345,7 +346,7 @@ describe('builders', () => {
     });
 
     it('builds empty todos from single add and multiple identical removes', () => {
-      const todoOperations: string[] = [
+      const todoOperations: Operation[] = [
         'add|ember-template-lint|no-implicit-this|174|8|174|8|864e3ef2438ac413d96a032cdd141e567fcc04b3|1629331200000|2493248400000|2493334800000|addon/templates/components/foo.hbs',
         'remove|ember-template-lint|no-implicit-this|174|8|174|8|864e3ef2438ac413d96a032cdd141e567fcc04b3|1629331200000|2493248400000|2493334800000|addon/templates/components/foo.hbs',
         'remove|ember-template-lint|no-implicit-this|174|8|174|8|864e3ef2438ac413d96a032cdd141e567fcc04b3|1629331200000|2493248400000|2493334800000|addon/templates/components/foo.hbs',

--- a/tests/io-test.ts
+++ b/tests/io-test.ts
@@ -149,12 +149,16 @@ describe('io', () => {
 
       writeTodoStorageFile(todoStorageFilePath, operations);
 
-      compactTodoStorageFile(tmp, buildReadOptions());
+      const { originalOperations, compactedOperations, compacted } = compactTodoStorageFile(tmp, buildReadOptions());
 
       expect(readTodoStorageFile(todoStorageFilePath)).toEqual(operations);
 
       const todoContents = readFileSync(todoStorageFilePath, { encoding: 'utf8' });
       expect(todoContents.endsWith(EOL)).toEqual(true)
+
+      expect(originalOperations).toEqual(operations)
+      expect(compactedOperations).toEqual(operations)
+      expect(compacted).toEqual(0)
     });
 
     it('compacts existing file when remove operations are present', () => {
@@ -163,20 +167,24 @@ describe('io', () => {
         'add|eslint|no-prototype-builtins|25|21|25|35|da39a3ee5e6b4b0d3255bfef95601890afd80709|1637107200000|||app/controllers/settings.js',
         'add|eslint|no-prototype-builtins|26|19|26|33|da39a3ee5e6b4b0d3255bfef95601890afd80709|1637107200000|||app/controllers/settings.js',
       ];
-
       const removeOperations: Operation[] = [
         'remove|eslint|no-prototype-builtins|25|21|25|35|da39a3ee5e6b4b0d3255bfef95601890afd80709|1637107200000|||app/controllers/settings.js',
         'remove|eslint|no-prototype-builtins|26|19|26|33|da39a3ee5e6b4b0d3255bfef95601890afd80709|1637107200000|||app/controllers/settings.js',
       ];
+      const operations = [...addOperations, ...removeOperations]
 
-      writeTodoStorageFile(todoStorageFilePath, [...addOperations, ...removeOperations]);
+      writeTodoStorageFile(todoStorageFilePath, operations);
 
-      compactTodoStorageFile(tmp);
+      const { originalOperations, compactedOperations, compacted } = compactTodoStorageFile(tmp);
 
-      expect(readTodoStorageFile(todoStorageFilePath)).toEqual([]);
+      expect(readTodoStorageFile(todoStorageFilePath)).toEqual(compactedOperations);
 
       const todoContents = readFileSync(todoStorageFilePath, { encoding: 'utf8' });
       expect(todoContents.endsWith(EOL)).toEqual(true)
+
+      expect(originalOperations).toEqual(operations)
+      expect(compactedOperations).toEqual([])
+      expect(compacted).toEqual(4)
     });
 
     it('compacts existing file when interleaved remove operations are present', () => {
@@ -192,12 +200,16 @@ describe('io', () => {
 
       writeTodoStorageFile(todoStorageFilePath, operations);
 
-      compactTodoStorageFile(tmp);
+      const { originalOperations, compactedOperations, compacted } = compactTodoStorageFile(tmp);
 
-      expect(readTodoStorageFile(todoStorageFilePath)).toEqual([
+      expect(readTodoStorageFile(todoStorageFilePath)).toEqual(compactedOperations);
+
+      expect(originalOperations).toEqual(operations)
+      expect(compactedOperations).toEqual([
         'add|eslint|no-prototype-builtins|65|27|65|41|da39a3ee5e6b4b0d3255bfef95601890afd80709|1637107200000|||tests/unit/services/insights-test.js',
         'add|eslint|no-prototype-builtins|80|27|80|41|da39a3ee5e6b4b0d3255bfef95601890afd80709|1637107200000|||tests/unit/services/insights-test.js',
-      ]);
+      ])
+      expect(compacted).toEqual(4)
     });
 
     it('compacts respects multiple co-existing engines', () => {
@@ -215,15 +227,19 @@ describe('io', () => {
 
       writeTodoStorageFile(todoStorageFilePath, operations);
 
-      compactTodoStorageFile(tmp);
+      const { originalOperations, compactedOperations, compacted } = compactTodoStorageFile(tmp);
 
-      expect(readTodoStorageFile(todoStorageFilePath)).toEqual([
+      expect(readTodoStorageFile(todoStorageFilePath)).toEqual(compactedOperations);
+
+      expect(originalOperations).toEqual(operations)
+      expect(compactedOperations).toEqual([
         'add|eslint|no-prototype-builtins|30|21|25|35|da39a3ee5e6b4b0d3255bfef95601890afd80709|1637107200000|||app/controllers/settings.js',
         'add|ember-template-lint|no-html-comments|26|19|26|33|da39a3ee5e6b4b0d3255bfef95601890afd80709|1637107200000|||app/templates/settings.hbs',
         'add|eslint|no-prototype-builtins|65|27|65|41|da39a3ee5e6b4b0d3255bfef95601890afd80709|1637107200000|||tests/unit/services/insights-test.js',
         'add|eslint|no-prototype-builtins|90|27|65|41|da39a3ee5e6b4b0d3255bfef95601890afd80709|1637107200000|||tests/unit/services/insights-test.js',
         'add|ember-template-lint|no-html-comments|80|27|80|41|da39a3ee5e6b4b0d3255bfef95601890afd80709|1637107200000|||app/templates/insights.hbs',
-      ]);
+      ])
+      expect(compacted).toEqual(3)
     });
   });
 

--- a/tests/io-test.ts
+++ b/tests/io-test.ts
@@ -38,6 +38,7 @@ import {
   readTodoStorageFile,
   resolveConflicts,
   writeTodoStorageFile,
+  appendTodoStorageFile,
 } from '../src/io';
 
 function chunk<T>(initial: Set<T>, firstChunk = 1): [Set<T>, Set<T>] {
@@ -113,6 +114,28 @@ describe('io', () => {
 
       const todoContents = readFileSync(todoStorageFilePath, { encoding: 'utf8' });
       expect(todoContents).toEqual(operations[0] + EOL + operations[1] + EOL)
+    })
+  })
+
+  describe('appendTodoStorageFile', () => {
+    it('appends operations, joining with EOL and ending with EOL', () => {
+      const todoStorageFilePath = getTodoStorageFilePath(tmp);
+      const operations: Operation[] = [
+        'add|eslint|no-prototype-builtins|25|21|25|35|da39a3ee5e6b4b0d3255bfef95601890afd80709|1637107200000|||app/controllers/settings.js',
+        'add|eslint|no-prototype-builtins|26|19|26|33|da39a3ee5e6b4b0d3255bfef95601890afd80709|1637107200000|||app/controllers/settings.js',
+      ];
+
+      writeTodoStorageFile(todoStorageFilePath, operations);
+
+      const moreOperations: Operation[] = [
+        'add|eslint|no-prototype-builtins|27|21|25|35|da39a3ee5e6b4b0d3255bfef95601890afd80709|1637107200000|||app/controllers/settings.js',
+        'add|eslint|no-prototype-builtins|28|19|26|33|da39a3ee5e6b4b0d3255bfef95601890afd80709|1637107200000|||app/controllers/settings.js',
+      ];
+
+      appendTodoStorageFile(todoStorageFilePath, moreOperations)
+
+      const todoContents = readFileSync(todoStorageFilePath, { encoding: 'utf8' });
+      expect(todoContents).toEqual(operations[0] + EOL + operations[1] + EOL + moreOperations[0] + EOL + moreOperations[1] + EOL)
     })
   })
 

--- a/tests/io-test.ts
+++ b/tests/io-test.ts
@@ -1,6 +1,7 @@
 import { describe, beforeEach, it, expect } from 'vitest';
-import { existsSync } from 'fs-extra';
+import { existsSync, readFileSync } from 'fs-extra';
 import { subDays } from 'date-fns';
+import { EOL } from 'node:os';
 import {
   getDatePart,
   getTodoStorageFilePath,
@@ -100,6 +101,21 @@ describe('io', () => {
     });
   });
 
+  describe('writeTodoStorageFile', () => {
+    it('writes operations, joining with EOL and ending with EOL', () => {
+      const todoStorageFilePath = getTodoStorageFilePath(tmp);
+      const operations: Operation[] = [
+        'add|eslint|no-prototype-builtins|25|21|25|35|da39a3ee5e6b4b0d3255bfef95601890afd80709|1637107200000|||app/controllers/settings.js',
+        'add|eslint|no-prototype-builtins|26|19|26|33|da39a3ee5e6b4b0d3255bfef95601890afd80709|1637107200000|||app/controllers/settings.js',
+      ];
+
+      writeTodoStorageFile(todoStorageFilePath, operations);
+
+      const todoContents = readFileSync(todoStorageFilePath, { encoding: 'utf8' });
+      expect(todoContents).toEqual(operations[0] + EOL + operations[1] + EOL)
+    })
+  })
+
   describe('compactTodoStorageFile', () => {
     it('preserves existing file when no remove operations are present', () => {
       const todoStorageFilePath = getTodoStorageFilePath(tmp);
@@ -113,6 +129,9 @@ describe('io', () => {
       compactTodoStorageFile(tmp, buildReadOptions());
 
       expect(readTodoStorageFile(todoStorageFilePath)).toEqual(operations);
+
+      const todoContents = readFileSync(todoStorageFilePath, { encoding: 'utf8' });
+      expect(todoContents.endsWith(EOL)).toEqual(true)
     });
 
     it('compacts existing file when remove operations are present', () => {
@@ -132,6 +151,9 @@ describe('io', () => {
       compactTodoStorageFile(tmp);
 
       expect(readTodoStorageFile(todoStorageFilePath)).toEqual([]);
+
+      const todoContents = readFileSync(todoStorageFilePath, { encoding: 'utf8' });
+      expect(todoContents.endsWith(EOL)).toEqual(true)
     });
 
     it('compacts existing file when interleaved remove operations are present', () => {

--- a/tests/io-test.ts
+++ b/tests/io-test.ts
@@ -83,6 +83,12 @@ function buildReadOptions(options?: Partial<ReadTodoOptions>) {
   );
 }
 
+function joinOperations(...operations: (Operation[] | Operation)[]): string {
+  // eslint-disable-next-line unicorn/prefer-spread
+  const flatOperations = ([] as Operation[]).concat(...operations);
+  return flatOperations.join(EOL) + EOL;
+}
+
 describe('io', () => {
   let tmp: string;
 
@@ -113,7 +119,7 @@ describe('io', () => {
       writeTodoStorageFile(todoStorageFilePath, operations);
 
       const todoContents = readFileSync(todoStorageFilePath, { encoding: 'utf8' });
-      expect(todoContents).toEqual(operations[0] + EOL + operations[1] + EOL);
+      expect(todoContents).toEqual(joinOperations(operations));
     });
   });
 
@@ -135,16 +141,7 @@ describe('io', () => {
       appendTodoStorageFile(todoStorageFilePath, moreOperations);
 
       const todoContents = readFileSync(todoStorageFilePath, { encoding: 'utf8' });
-      expect(todoContents).toEqual(
-        operations[0] +
-          EOL +
-          operations[1] +
-          EOL +
-          moreOperations[0] +
-          EOL +
-          moreOperations[1] +
-          EOL
-      );
+      expect(todoContents).toEqual(joinOperations(operations, moreOperations));
     });
   });
 

--- a/tests/io-test.ts
+++ b/tests/io-test.ts
@@ -113,9 +113,9 @@ describe('io', () => {
       writeTodoStorageFile(todoStorageFilePath, operations);
 
       const todoContents = readFileSync(todoStorageFilePath, { encoding: 'utf8' });
-      expect(todoContents).toEqual(operations[0] + EOL + operations[1] + EOL)
-    })
-  })
+      expect(todoContents).toEqual(operations[0] + EOL + operations[1] + EOL);
+    });
+  });
 
   describe('appendTodoStorageFile', () => {
     it('appends operations, joining with EOL and ending with EOL', () => {
@@ -132,12 +132,21 @@ describe('io', () => {
         'add|eslint|no-prototype-builtins|28|19|26|33|da39a3ee5e6b4b0d3255bfef95601890afd80709|1637107200000|||app/controllers/settings.js',
       ];
 
-      appendTodoStorageFile(todoStorageFilePath, moreOperations)
+      appendTodoStorageFile(todoStorageFilePath, moreOperations);
 
       const todoContents = readFileSync(todoStorageFilePath, { encoding: 'utf8' });
-      expect(todoContents).toEqual(operations[0] + EOL + operations[1] + EOL + moreOperations[0] + EOL + moreOperations[1] + EOL)
-    })
-  })
+      expect(todoContents).toEqual(
+        operations[0] +
+          EOL +
+          operations[1] +
+          EOL +
+          moreOperations[0] +
+          EOL +
+          moreOperations[1] +
+          EOL
+      );
+    });
+  });
 
   describe('compactTodoStorageFile', () => {
     it('preserves existing file when no remove operations are present', () => {
@@ -149,16 +158,16 @@ describe('io', () => {
 
       writeTodoStorageFile(todoStorageFilePath, operations);
 
-      const { originalOperations, compactedOperations, compacted } = compactTodoStorageFile(tmp, buildReadOptions());
+      const { originalOperations, compactedOperations, compacted } = compactTodoStorageFile(tmp);
 
       expect(readTodoStorageFile(todoStorageFilePath)).toEqual(operations);
 
       const todoContents = readFileSync(todoStorageFilePath, { encoding: 'utf8' });
-      expect(todoContents.endsWith(EOL)).toEqual(true)
+      expect(todoContents.endsWith(EOL)).toEqual(true);
 
-      expect(originalOperations).toEqual(operations)
-      expect(compactedOperations).toEqual(operations)
-      expect(compacted).toEqual(0)
+      expect(originalOperations).toEqual(operations);
+      expect(compactedOperations).toEqual(operations);
+      expect(compacted).toEqual(0);
     });
 
     it('compacts existing file when remove operations are present', () => {
@@ -171,7 +180,7 @@ describe('io', () => {
         'remove|eslint|no-prototype-builtins|25|21|25|35|da39a3ee5e6b4b0d3255bfef95601890afd80709|1637107200000|||app/controllers/settings.js',
         'remove|eslint|no-prototype-builtins|26|19|26|33|da39a3ee5e6b4b0d3255bfef95601890afd80709|1637107200000|||app/controllers/settings.js',
       ];
-      const operations = [...addOperations, ...removeOperations]
+      const operations = [...addOperations, ...removeOperations];
 
       writeTodoStorageFile(todoStorageFilePath, operations);
 
@@ -180,11 +189,11 @@ describe('io', () => {
       expect(readTodoStorageFile(todoStorageFilePath)).toEqual(compactedOperations);
 
       const todoContents = readFileSync(todoStorageFilePath, { encoding: 'utf8' });
-      expect(todoContents.endsWith(EOL)).toEqual(true)
+      expect(todoContents.endsWith(EOL)).toEqual(true);
 
-      expect(originalOperations).toEqual(operations)
-      expect(compactedOperations).toEqual([])
-      expect(compacted).toEqual(4)
+      expect(originalOperations).toEqual(operations);
+      expect(compactedOperations).toEqual([]);
+      expect(compacted).toEqual(4);
     });
 
     it('compacts existing file when interleaved remove operations are present', () => {
@@ -204,12 +213,12 @@ describe('io', () => {
 
       expect(readTodoStorageFile(todoStorageFilePath)).toEqual(compactedOperations);
 
-      expect(originalOperations).toEqual(operations)
+      expect(originalOperations).toEqual(operations);
       expect(compactedOperations).toEqual([
         'add|eslint|no-prototype-builtins|65|27|65|41|da39a3ee5e6b4b0d3255bfef95601890afd80709|1637107200000|||tests/unit/services/insights-test.js',
         'add|eslint|no-prototype-builtins|80|27|80|41|da39a3ee5e6b4b0d3255bfef95601890afd80709|1637107200000|||tests/unit/services/insights-test.js',
-      ])
-      expect(compacted).toEqual(4)
+      ]);
+      expect(compacted).toEqual(4);
     });
 
     it('compacts respects multiple co-existing engines', () => {
@@ -231,15 +240,15 @@ describe('io', () => {
 
       expect(readTodoStorageFile(todoStorageFilePath)).toEqual(compactedOperations);
 
-      expect(originalOperations).toEqual(operations)
+      expect(originalOperations).toEqual(operations);
       expect(compactedOperations).toEqual([
         'add|eslint|no-prototype-builtins|30|21|25|35|da39a3ee5e6b4b0d3255bfef95601890afd80709|1637107200000|||app/controllers/settings.js',
         'add|ember-template-lint|no-html-comments|26|19|26|33|da39a3ee5e6b4b0d3255bfef95601890afd80709|1637107200000|||app/templates/settings.hbs',
         'add|eslint|no-prototype-builtins|65|27|65|41|da39a3ee5e6b4b0d3255bfef95601890afd80709|1637107200000|||tests/unit/services/insights-test.js',
         'add|eslint|no-prototype-builtins|90|27|65|41|da39a3ee5e6b4b0d3255bfef95601890afd80709|1637107200000|||tests/unit/services/insights-test.js',
         'add|ember-template-lint|no-html-comments|80|27|80|41|da39a3ee5e6b4b0d3255bfef95601890afd80709|1637107200000|||app/templates/insights.hbs',
-      ])
-      expect(compacted).toEqual(3)
+      ]);
+      expect(compacted).toEqual(3);
     });
   });
 
@@ -356,6 +365,8 @@ remove|eslint|no-unused-vars|30|19|30|33|da39a3ee5e6b4b0d3255bfef95601890afd8070
           fixableWarningCount: 0,
           source: '',
           usedDeprecatedRules: [],
+          suppressedMessages: [],
+          fatalErrorCount: 0,
         },
       ];
 


### PR DESCRIPTION
I've been seeing this issue for a very long time, so thought I'd contribute a fix.

This PR ensures that compact-todo writes an EOL at the end of the file.
It also adds several tests for existing functions

---

Fixes an issue where running compact todo would always result in a file that is missing an EOL at the end. This then compounds into further issues, - if you then later update the todo file (or some other task that appends) then you end up with a doubled-operation line like this

(scroll along to see the two ops on the same line)
```
add|ember-template-lint|no-bare-strings|9|11|9|11|1075c086b703df3b01e8d6013dae65668d6d865d|1690848000000|||app/components/charts/dashboard/awards-earned/trophy/template.hbsadd|ember-template-lint|no-bare-strings|14|11|14|11|6d12c8adbefeaeacac0d48274df3a195ca9a1d17|1690848000000|||app/components/charts/dashboard/awards-earned/badge/template.hbs
```
That doubled operation line would be ignored, and the linter would tell you there are problems again. You call update-todo to re-add the line to make the error go away... you end up with a bunch of doubled operations throughout the file. They don't ever get cleaned up
